### PR TITLE
Update uhdm-integration repo url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/alainmarcel/Surelog.git
 [submodule "uhdm-integration"]
 	path = uhdm-integration
-	url = https://github.com/antmicro/uhdm-integration.git
+	url = https://github.com/alainmarcel/uhdm-integration.git


### PR DESCRIPTION
This PR switches ``uhdm-integration`` repository from ``antmicro`` to ``alainmarcel``.