### PR TITLE
Change CI branch to uhdm-verilator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: 'main'
 on:
   push:
     branches:
-      - master
+      - uhdm-verilator
   pull_request:
 
 jobs:


### PR DESCRIPTION
This PR changes push CI branch from ``master`` to ``uhdm-verilator``.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>
