### PR TITLE
Test simulator_ctrl and ibex_register_file_latch

### DIFF
--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -968,19 +968,10 @@ namespace UhdmAst {
           } else {
             AstNode* assign;
             if (lvalue->type() == AstType::en::atVar) {
-              // If a variable was declared along with the assignment,
-              // return it as well. Create a reference for the assignment.
-              AstNode* var = lvalue;
-              auto* var_ref = new AstParseRef(new FileLine("uhdm"),
-                                                     VParseRefExp::en::PX_TEXT,
-                                                     lvalue->name(),
-                                                     nullptr,
-                                                     nullptr);
-              if (objectType == vpiContAssign)
-                assign = new AstAssignW(new FileLine("uhdm"), var_ref, rvalue);
-              else
-                assign = new AstAssign(new FileLine("uhdm"), var_ref, rvalue);
-              var->addNextNull(assign);
+              // This is not a true assignment
+              // Set initial value to a variable and return it
+              AstVar* var = static_cast<AstVar*>(lvalue);
+              var->valuep(rvalue);
               return var;
             } else {
               if (objectType == vpiContAssign)

--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -2428,6 +2428,8 @@ namespace UhdmAst {
           return new AstFClose(new FileLine("uhdm"),
                               arguments[0]);
         } else if (objectName == "$fwrite") {
+          AstNode* filep = arguments[0];
+          arguments.erase(arguments.begin());
           AstNode* args = nullptr;
           for (auto a : arguments) {
             if (args == nullptr)
@@ -2437,7 +2439,7 @@ namespace UhdmAst {
           }
           return new AstDisplay(new FileLine("uhdm"),
                                 AstDisplayType(AstDisplayType::en::DT_WRITE),
-                                nullptr,
+                                filep,
                                 args);
         } else if (objectName == "$fflush") {
           return new AstFFlush(new FileLine("uhdm"),

--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -2537,7 +2537,7 @@ namespace UhdmAst {
                                   arguments[2],
                                   arguments[3]);
           }
-        } else if (objectName == "$error") {
+        } else if (objectName == "$error" || objectName == "$fatal") {
           //TODO: Revisit argument handling
           bool maybe = arguments.size() ? false : true;
           return new AstStop(new FileLine("uhdm"), maybe);

--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -2537,10 +2537,29 @@ namespace UhdmAst {
                                   arguments[2],
                                   arguments[3]);
           }
-        } else if (objectName == "$error" || objectName == "$fatal") {
-          //TODO: Revisit argument handling
-          bool maybe = arguments.size() ? false : true;
-          return new AstStop(new FileLine("uhdm"), maybe);
+        } else if (objectName == "$error") {
+          AstNode* args = nullptr;
+          for (auto a : arguments) {
+            if (args == nullptr)
+              args = a;
+            else
+              args->addNextNull(a);
+          }
+          node = new AstDisplay(new FileLine("uhdm"),
+                                AstDisplayType::DT_ERROR,
+                                nullptr,
+                                args);
+          auto* stop = new AstStop(new FileLine("uhdm"), true);
+          node->addNext(stop);
+          return node;
+        } else if (objectName == "$fatal") {
+          node = new AstDisplay(new FileLine("uhdm"),
+                                AstDisplayType::DT_FATAL,
+                                nullptr,
+                                nullptr);
+          auto* stop = new AstStop(new FileLine("uhdm"), false);
+          node->addNext(stop);
+          return node;
         } else if (objectName == "$__BAD_SYMBOL__") {
           v3info("\t! Bad symbol encountered @ "
                  << file_name << ":" << currentLine);

--- a/uhdm-tests/ibex/Makefile.in
+++ b/uhdm-tests/ibex/Makefile.in
@@ -35,13 +35,28 @@ IBEX_SOURCES_DELETE_OR = \
 	$(shell \
 		echo ${IBEX_SOURCES_DELETE} | sed 's/\s/\\|/g')
 
+# Use up to 8 threads for simulated model (related to design parallelism factor)
+CPU_COUNT := $(shell nproc)
+CPUS_GT_8 := $(shell [ ${CPU_COUNT} -gt 8 ] && echo true )
+ifeq ($(CPUS_GT_8),true)
+	THREAD_COUNT = 8
+else
+	THREAD_COUNT = ${CPU_COUNT}
+endif
+
 prepare-sources:
 	virtualenv ${root_dir}/venv-ibex
 	(export PATH=${root_dir}/../image/bin:${PATH} && \
 		. ${root_dir}/venv-ibex/bin/activate && \
 		pip install -r ${IBEX}/python-requirements.txt && \
 		pip install git+https://github.com/antmicro/edalize@surelog && \
-		fusesoc --cores-root=${IBEX} run --target=sim --setup lowrisc:ibex:ibex_simple_system --RV32E=0 --RV32M=ibex_pkg::RV32MFast)
+		fusesoc --cores-root=${IBEX} run \
+			--target=sim \
+			--setup lowrisc:ibex:ibex_simple_system \
+			--RV32E=0 \
+			--RV32M=ibex_pkg::RV32MFast \
+			--verilator_options '--threads $(THREAD_COUNT)' \
+			)
 
 uhdm/verilator/simple-system: clean-build | prepare-sources
 	(export PATH=${root_dir}/../image/bin:${PATH} && \

--- a/uhdm-tests/ibex/Makefile.in
+++ b/uhdm-tests/ibex/Makefile.in
@@ -15,7 +15,7 @@ IBEX_INCLUDE = \
 	-I$(IBEX_BUILD)/src/lowrisc_dv_verilator_memutil_verilator_0/cpp
 
 #Sources that will be skipped by Surelog uhdm
-SKIP_SOURCES=prim_generic_ram_2p.sv\|prim_ram_2p.sv\|ram_2p.sv\|bus.sv\|simulator_ctrl.sv\|ibex_register_file_latch.sv\|ibex_simple_system.sv
+SKIP_SOURCES=prim_generic_ram_2p.sv\|prim_ram_2p.sv\|ram_2p.sv\|bus.sv\|ibex_simple_system.sv
 
 # Top-level parameters in skipped modules that need to be known to Surelog
 SURELOG_PARAMETERS = -PMHPMCounterNum=29 +define+RVFI #TODO: Remove when ibex_simple_system is removed from skip list


### PR DESCRIPTION
Remove simulator_ctrl and ibex_register_file_latch from the skip list and parse them using UHDM.
Fixes https://github.com/alainmarcel/uhdm-integration/issues/154.
Fixes https://github.com/alainmarcel/uhdm-integration/issues/152.