### PR TITLE
Run clang-format on frontend code

### DIFF
--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -11,66 +11,64 @@
 
 namespace UhdmAst {
 
-  std::map<std::string, AstPackage*> package_map;
-  std::string package_prefix;
-  std::map<std::string, AstNode*> partialModules;
-  std::unordered_map<const UHDM::BaseClass*, std::string> visited_types;
-  std::set<std::tuple<std::string, int, std::string>> coverage_set;
-  V3ParseSym* m_symp;
+std::map<std::string, AstPackage*> package_map;
+std::string package_prefix;
+std::map<std::string, AstNode*> partialModules;
+std::unordered_map<const UHDM::BaseClass*, std::string> visited_types;
+std::set<std::tuple<std::string, int, std::string>> coverage_set;
+V3ParseSym* m_symp;
 
-  // Walks through one-to-many relationships from given parent
-  // node through the VPI interface, visiting child nodes belonging to
-  // ChildrenNodeTypes that are present in the given object.
-  void visit_one_to_many (const std::vector<int> childrenNodeTypes,
-                          vpiHandle parentHandle,
-                          std::set<const UHDM::BaseClass*> visited,
-                          std::map<std::string, AstNodeModule*>* top_nodes,
-                          const std::function<void(AstNode*)> &f) {
+// Walks through one-to-many relationships from given parent
+// node through the VPI interface, visiting child nodes belonging to
+// ChildrenNodeTypes that are present in the given object.
+void visit_one_to_many(const std::vector<int> childrenNodeTypes, vpiHandle parentHandle,
+                       std::set<const UHDM::BaseClass*> visited,
+                       std::map<std::string, AstNodeModule*>* top_nodes,
+                       const std::function<void(AstNode*)>& f) {
     for (auto child : childrenNodeTypes) {
-      vpiHandle itr = vpi_iterate(child, parentHandle);
-      while (vpiHandle vpi_child_obj = vpi_scan(itr) ) {
-        auto *childNode = visit_object(vpi_child_obj, visited, top_nodes);
-        f(childNode);
-        vpi_free_object(vpi_child_obj);
-      }
-      vpi_free_object(itr);
+        vpiHandle itr = vpi_iterate(child, parentHandle);
+        while (vpiHandle vpi_child_obj = vpi_scan(itr)) {
+            auto* childNode = visit_object(vpi_child_obj, visited, top_nodes);
+            f(childNode);
+            vpi_free_object(vpi_child_obj);
+        }
+        vpi_free_object(itr);
     }
-  }
+}
 
-  // Walks through one-to-one relationships from given parent
-  // node through the VPI interface, visiting child nodes belonging to
-  // ChildrenNodeTypes that are present in the given object.
-  void visit_one_to_one (const std::vector<int> childrenNodeTypes,
-                         vpiHandle parentHandle,
-                         std::set<const UHDM::BaseClass*> visited,
-                         std::map<std::string, AstNodeModule*>* top_nodes,
-                         const std::function<void(AstNode*)> &f) {
+// Walks through one-to-one relationships from given parent
+// node through the VPI interface, visiting child nodes belonging to
+// ChildrenNodeTypes that are present in the given object.
+void visit_one_to_one(const std::vector<int> childrenNodeTypes, vpiHandle parentHandle,
+                      std::set<const UHDM::BaseClass*> visited,
+                      std::map<std::string, AstNodeModule*>* top_nodes,
+                      const std::function<void(AstNode*)>& f) {
     for (auto child : childrenNodeTypes) {
-      vpiHandle itr = vpi_handle(child, parentHandle);
-      if (itr) {
-        auto *childNode = visit_object(itr, visited, top_nodes);
-        f(childNode);
-      }
-      vpi_free_object(itr);
+        vpiHandle itr = vpi_handle(child, parentHandle);
+        if (itr) {
+            auto* childNode = visit_object(itr, visited, top_nodes);
+            f(childNode);
+        }
+        vpi_free_object(itr);
     }
-  }
+}
 
-  void sanitize_str(std::string &s) {
+void sanitize_str(std::string& s) {
     if (!s.empty()) {
-      auto pos = s.find_last_of("@");
-      s = s.substr(pos+1);
+        auto pos = s.find_last_of("@");
+        s = s.substr(pos + 1);
     }
-  }
+}
 
-  bool is_imported(vpiHandle obj_h) {
+bool is_imported(vpiHandle obj_h) {
     if (auto s = vpi_get_str(vpiImported, obj_h)) {
-      return true;
+        return true;
     } else {
-      return false;
+        return false;
     }
-  }
+}
 
-  string deQuote(FileLine* fileline, string text) {
+string deQuote(FileLine* fileline, string text) {
     // Fix up the quoted strings the user put in, for example "\"" becomes "
     // Reverse is V3OutFormatter::quoteNameControls(...)
     bool quoted = false;
@@ -78,405 +76,373 @@ namespace UhdmAst {
     unsigned char octal_val = 0;
     int octal_digits = 0;
     for (string::const_iterator cp = text.begin(); cp != text.end(); ++cp) {
-      if (quoted) {
-        if (isdigit(*cp)) {
-          octal_val = octal_val*8 + (*cp-'0');
-          if (++octal_digits == 3) {
+        if (quoted) {
+            if (isdigit(*cp)) {
+                octal_val = octal_val * 8 + (*cp - '0');
+                if (++octal_digits == 3) {
+                    octal_digits = 0;
+                    quoted = false;
+                    newtext += octal_val;
+                }
+            } else {
+                if (octal_digits) {
+                    // Spec allows 1-3 digits
+                    octal_digits = 0;
+                    quoted = false;
+                    newtext += octal_val;
+                    --cp;  // Backup to reprocess terminating character as non-escaped
+                    continue;
+                }
+                quoted = false;
+                if (*cp == 'n')
+                    newtext += '\n';
+                else if (*cp == 'a')
+                    newtext += '\a';  // SystemVerilog 3.1
+                else if (*cp == 'f')
+                    newtext += '\f';  // SystemVerilog 3.1
+                else if (*cp == 'r')
+                    newtext += '\r';
+                else if (*cp == 't')
+                    newtext += '\t';
+                else if (*cp == 'v')
+                    newtext += '\v';  // SystemVerilog 3.1
+                else if (*cp == 'x' && isxdigit(cp[1]) && isxdigit(cp[2])) {  // SystemVerilog 3.1
+#define vl_decodexdigit(c) ((isdigit(c) ? ((c) - '0') : (tolower((c)) - 'a' + 10)))
+                    newtext += (char)(16 * vl_decodexdigit(cp[1]) + vl_decodexdigit(cp[2]));
+                    cp += 2;
+                } else if (isalnum(*cp)) {
+                    fileline->v3error("Unknown escape sequence: \\" << *cp);
+                    break;
+                } else
+                    newtext += *cp;
+            }
+        } else if (*cp == '\\') {
+            quoted = true;
             octal_digits = 0;
-            quoted = false;
-            newtext += octal_val;
-          }
-        } else {
-          if (octal_digits) {
-            // Spec allows 1-3 digits
-            octal_digits = 0;
-            quoted = false;
-            newtext += octal_val;
-            --cp;  // Backup to reprocess terminating character as non-escaped
-            continue;
-          }
-          quoted = false;
-          if (*cp == 'n') newtext += '\n';
-          else if (*cp == 'a') newtext += '\a';  // SystemVerilog 3.1
-          else if (*cp == 'f') newtext += '\f';  // SystemVerilog 3.1
-          else if (*cp == 'r') newtext += '\r';
-          else if (*cp == 't') newtext += '\t';
-          else if (*cp == 'v') newtext += '\v';  // SystemVerilog 3.1
-          else if (*cp == 'x' && isxdigit(cp[1]) && isxdigit(cp[2])) {  // SystemVerilog 3.1
-#define vl_decodexdigit(c) ((isdigit(c)?((c)-'0'):(tolower((c))-'a'+10)))
-            newtext += (char)(16*vl_decodexdigit(cp[1]) + vl_decodexdigit(cp[2]));
-            cp += 2;
-          }
-          else if (isalnum(*cp)) {
-            fileline->v3error("Unknown escape sequence: \\"<<*cp);
-            break;
-          }
-          else newtext += *cp;
+        } else if (*cp != '"') {
+            newtext += *cp;
         }
-      }
-      else if (*cp == '\\') {
-        quoted = true;
-        octal_digits = 0;
-      }
-      else if (*cp != '"') {
-        newtext += *cp;
-      }
     }
     return newtext;
-  }
+}
 
-  AstNode* get_value_as_node(vpiHandle obj_h) {
+AstNode* get_value_as_node(vpiHandle obj_h) {
     AstNode* value_node = nullptr;
     s_vpi_value val;
     vpi_get_value(obj_h, &val);
     switch (val.format) {
-      case vpiScalarVal: {
+    case vpiScalarVal: {
         std::string valStr = std::to_string(val.value.scalar);
         if (valStr[0] == '-') {
-          valStr = valStr.substr(1);
-          V3Number value(value_node, valStr.c_str());
-          auto* inner = new AstConst(new FileLine("uhdm"), value);
-          value_node = new AstNegate(new FileLine("uhdm"), inner);
-          break;
-        }
-        V3Number value(value_node, valStr.c_str());
-        value_node = new AstConst(new FileLine("uhdm"), value);
-        break;
-      }
-      case vpiIntVal: {
-        std::string valStr;
-        if (auto s = vpi_get_str(vpiDecompile, obj_h)) {
-          valStr = s;
-        } else {
-          valStr = std::to_string(val.value.integer);
-          if (valStr[0] == '-') {
             valStr = valStr.substr(1);
             V3Number value(value_node, valStr.c_str());
             auto* inner = new AstConst(new FileLine("uhdm"), value);
             value_node = new AstNegate(new FileLine("uhdm"), inner);
             break;
-          }
         }
         V3Number value(value_node, valStr.c_str());
         value_node = new AstConst(new FileLine("uhdm"), value);
         break;
-      }
-      case vpiRealVal: {
+    }
+    case vpiIntVal: {
+        std::string valStr;
+        if (auto s = vpi_get_str(vpiDecompile, obj_h)) {
+            valStr = s;
+        } else {
+            valStr = std::to_string(val.value.integer);
+            if (valStr[0] == '-') {
+                valStr = valStr.substr(1);
+                V3Number value(value_node, valStr.c_str());
+                auto* inner = new AstConst(new FileLine("uhdm"), value);
+                value_node = new AstNegate(new FileLine("uhdm"), inner);
+                break;
+            }
+        }
+        V3Number value(value_node, valStr.c_str());
+        value_node = new AstConst(new FileLine("uhdm"), value);
+        break;
+    }
+    case vpiRealVal: {
         std::string valStr = std::to_string(val.value.real);
         V3Number value(value_node, valStr.c_str());
         value_node = new AstConst(new FileLine("uhdm"), value);
         break;
-      }
-      case vpiBinStrVal:
-      case vpiOctStrVal:
-      case vpiDecStrVal:
-      case vpiHexStrVal: {
+    }
+    case vpiBinStrVal:
+    case vpiOctStrVal:
+    case vpiDecStrVal:
+    case vpiHexStrVal: {
         std::string valStr;
         if (auto s = vpi_get_str(vpiDecompile, obj_h)) {
-          valStr = s;
+            valStr = s;
         } else {
-          // if vpiDecompile is unavailable i.e. in EnumConst, cast the string
-          // size is stored in enum typespec
-          if (val.format == vpiBinStrVal)
-            valStr = "'b" + std::string(val.value.str);
-          else if (val.format == vpiOctStrVal)
-            valStr = "'o" + std::string(val.value.str);
-          else if (val.format == vpiDecStrVal)
-            valStr = "'d" + std::string(val.value.str);
-          else if (val.format == vpiHexStrVal)
-            valStr = "'h" + std::string(val.value.str);
+            // if vpiDecompile is unavailable i.e. in EnumConst, cast the string
+            // size is stored in enum typespec
+            if (val.format == vpiBinStrVal)
+                valStr = "'b" + std::string(val.value.str);
+            else if (val.format == vpiOctStrVal)
+                valStr = "'o" + std::string(val.value.str);
+            else if (val.format == vpiDecStrVal)
+                valStr = "'d" + std::string(val.value.str);
+            else if (val.format == vpiHexStrVal)
+                valStr = "'h" + std::string(val.value.str);
         }
         auto size = vpi_get(vpiSize, obj_h);
         V3Number value(value_node, valStr.c_str());
         value_node = new AstConst(new FileLine("uhdm"), value);
         break;
-      }
-      case vpiStringVal: {
+    }
+    case vpiStringVal: {
         std::string valStr(val.value.str);
-        value_node = new AstConst(new FileLine("uhdm"),
-                                  AstConst::VerilogStringLiteral(),
+        value_node = new AstConst(new FileLine("uhdm"), AstConst::VerilogStringLiteral(),
                                   deQuote(new FileLine("uhdm"), valStr));
         break;
-      }
-      default: {
+    }
+    default: {
         break;
-      }
+    }
     }
     return value_node;
-  }
+}
 
-  AstBasicDTypeKwd get_kwd_for_type(int vpi_var_type) {
-    switch(vpi_var_type) {
-      case vpiLogicTypespec:
-      case vpiLogicNet:
-      case vpiLogicVar: {
+AstBasicDTypeKwd get_kwd_for_type(int vpi_var_type) {
+    switch (vpi_var_type) {
+    case vpiLogicTypespec:
+    case vpiLogicNet:
+    case vpiLogicVar: {
         return AstBasicDTypeKwd::LOGIC;
-      }
-      case vpiIntTypespec:
-      case vpiIntVar: {
+    }
+    case vpiIntTypespec:
+    case vpiIntVar: {
         return AstBasicDTypeKwd::INT;
-      }
-      case vpiLongIntTypespec:
-      case vpiLongIntVar: {
+    }
+    case vpiLongIntTypespec:
+    case vpiLongIntVar: {
         return AstBasicDTypeKwd::LONGINT;
-      }
-      case vpiIntegerTypespec:
-      case vpiIntegerNet:
-      case vpiIntegerVar: {
+    }
+    case vpiIntegerTypespec:
+    case vpiIntegerNet:
+    case vpiIntegerVar: {
         return AstBasicDTypeKwd::INTEGER;
-      }
-      case vpiBitTypespec:
-      case vpiBitVar: {
+    }
+    case vpiBitTypespec:
+    case vpiBitVar: {
         return AstBasicDTypeKwd::BIT;
-      }
-      case vpiByteTypespec:
-      case vpiByteVar: {
+    }
+    case vpiByteTypespec:
+    case vpiByteVar: {
         return AstBasicDTypeKwd::BYTE;
-      }
-      case vpiRealTypespec:
-      case vpiRealVar: {
+    }
+    case vpiRealTypespec:
+    case vpiRealVar: {
         return AstBasicDTypeKwd::DOUBLE;
-      }
-      case vpiStringTypespec:
-      case vpiStringVar: {
+    }
+    case vpiStringTypespec:
+    case vpiStringVar: {
         return AstBasicDTypeKwd::STRING;
-      }
-      case vpiTimeTypespec:
-      case vpiTimeNet:
-      case vpiTimeVar: {
+    }
+    case vpiTimeTypespec:
+    case vpiTimeNet:
+    case vpiTimeVar: {
         return AstBasicDTypeKwd::TIME;
-      }
-      case vpiEnumTypespec:
-      case vpiEnumVar:
-      case vpiEnumNet:
-      case vpiStructTypespec:
-      case vpiStructNet:
-      case vpiStructVar:
-      case vpiUnionTypespec: {
+    }
+    case vpiEnumTypespec:
+    case vpiEnumVar:
+    case vpiEnumNet:
+    case vpiStructTypespec:
+    case vpiStructNet:
+    case vpiStructVar:
+    case vpiUnionTypespec: {
         // Not a basic dtype, needs further handling
         return AstBasicDTypeKwd::UNKNOWN;
-      }
-      default:
-        v3error("Unknown object type");
+    }
+    default: v3error("Unknown object type");
     }
     return AstBasicDTypeKwd::UNKNOWN;
-  }
+}
 
-  AstNodeDType* getDType(vpiHandle obj_h,
-        std::set<const UHDM::BaseClass*> visited,
-        std::map<std::string, AstNodeModule*>* top_nodes) {
+AstNodeDType* getDType(vpiHandle obj_h, std::set<const UHDM::BaseClass*> visited,
+                       std::map<std::string, AstNodeModule*>* top_nodes) {
     AstNodeDType* dtype = nullptr;
     auto type = vpi_get(vpiType, obj_h);
     if (type == vpiPort) {
-      auto ref_h = vpi_handle(vpiLowConn, obj_h);
-      if (!ref_h) {
-        v3error("Could not get lowconn handle for port, aborting");
-        return nullptr;
-      }
-      auto actual_h = vpi_handle(vpiActual, ref_h);
-      if (!actual_h) {
-        v3error("Could not get actual handle for port, aborting");
-        return nullptr;
-      }
-      auto ref_type = vpi_get(vpiType, actual_h);
-      if (ref_type == vpiLogicNet ||
-          ref_type == vpiIntegerNet ||
-          ref_type == vpiTimeNet ||
-          ref_type == vpiArrayNet ||
-          ref_type == vpiPackedArrayNet) {
-        type = ref_type;
-        obj_h = actual_h;
-      } else if (ref_type == vpiEnumNet ||
-                 ref_type == vpiStructNet ||
-                 ref_type == vpiStructVar ||
-                 ref_type == vpiEnumVar) {
-        auto typespec_h = vpi_handle(vpiTypedef, obj_h);
-        if (typespec_h) {
-          type = vpi_get(vpiType, typespec_h);
-          obj_h = typespec_h;
+        auto ref_h = vpi_handle(vpiLowConn, obj_h);
+        if (!ref_h) {
+            v3error("Could not get lowconn handle for port, aborting");
+            return nullptr;
         }
-      } else if (ref_type == vpiModport ||
-                 ref_type == vpiInterface) {
-        // Special handling, generate only reference
-        vpiHandle iface_h = nullptr;
-        if (ref_type == vpiModport) {
-          iface_h = vpi_handle(vpiInterface, actual_h);
-        } else if (ref_type == vpiInterface) {
-          iface_h = actual_h;
+        auto actual_h = vpi_handle(vpiActual, ref_h);
+        if (!actual_h) {
+            v3error("Could not get actual handle for port, aborting");
+            return nullptr;
         }
-        std::string cellName, ifaceName;
-        if (auto s = vpi_get_str(vpiName, ref_h)) {
-          cellName = s;
-          sanitize_str(cellName);
+        auto ref_type = vpi_get(vpiType, actual_h);
+        if (ref_type == vpiLogicNet || ref_type == vpiIntegerNet || ref_type == vpiTimeNet
+            || ref_type == vpiArrayNet || ref_type == vpiPackedArrayNet) {
+            type = ref_type;
+            obj_h = actual_h;
+        } else if (ref_type == vpiEnumNet || ref_type == vpiStructNet || ref_type == vpiStructVar
+                   || ref_type == vpiEnumVar) {
+            auto typespec_h = vpi_handle(vpiTypedef, obj_h);
+            if (typespec_h) {
+                type = vpi_get(vpiType, typespec_h);
+                obj_h = typespec_h;
+            }
+        } else if (ref_type == vpiModport || ref_type == vpiInterface) {
+            // Special handling, generate only reference
+            vpiHandle iface_h = nullptr;
+            if (ref_type == vpiModport) {
+                iface_h = vpi_handle(vpiInterface, actual_h);
+            } else if (ref_type == vpiInterface) {
+                iface_h = actual_h;
+            }
+            std::string cellName, ifaceName;
+            if (auto s = vpi_get_str(vpiName, ref_h)) {
+                cellName = s;
+                sanitize_str(cellName);
+            }
+            if (auto s = vpi_get_str(vpiDefName, iface_h)) {
+                ifaceName = s;
+                sanitize_str(ifaceName);
+            }
+            return new AstIfaceRefDType(new FileLine("uhdm"), cellName, ifaceName);
         }
-        if (auto s = vpi_get_str(vpiDefName, iface_h)) {
-          ifaceName = s;
-          sanitize_str(ifaceName);
-        }
-        return new AstIfaceRefDType(new FileLine("uhdm"),
-                                     cellName,
-                                     ifaceName);
-      }
     }
-    if (type == vpiEnumNet ||
-        type == vpiStructNet ||
-        type == vpiStructVar ||
-        type == vpiEnumVar) {
-      auto typespec_h = vpi_handle(vpiTypespec, obj_h);
-      if (typespec_h) {
-        type = vpi_get(vpiType, typespec_h);
-        obj_h = typespec_h;
-      }
+    if (type == vpiEnumNet || type == vpiStructNet || type == vpiStructVar || type == vpiEnumVar) {
+        auto typespec_h = vpi_handle(vpiTypespec, obj_h);
+        if (typespec_h) {
+            type = vpi_get(vpiType, typespec_h);
+            obj_h = typespec_h;
+        }
     }
     AstBasicDTypeKwd keyword = AstBasicDTypeKwd::UNKNOWN;
-    switch(type) {
-      case vpiLogicNet:
-      case vpiIntegerNet:
-      case vpiTimeNet:
-      case vpiLogicVar:
-      case vpiIntVar:
-      case vpiLongIntVar:
-      case vpiIntegerVar:
-      case vpiBitVar:
-      case vpiByteVar:
-      case vpiRealVar:
-      case vpiStringVar:
-      case vpiTimeVar:
-      case vpiLogicTypespec:
-      case vpiIntTypespec:
-      case vpiLongIntTypespec:
-      case vpiIntegerTypespec:
-      case vpiBitTypespec:
-      case vpiByteTypespec:
-      case vpiRealTypespec:
-      case vpiStringTypespec:
-      case vpiTimeTypespec: {
+    switch (type) {
+    case vpiLogicNet:
+    case vpiIntegerNet:
+    case vpiTimeNet:
+    case vpiLogicVar:
+    case vpiIntVar:
+    case vpiLongIntVar:
+    case vpiIntegerVar:
+    case vpiBitVar:
+    case vpiByteVar:
+    case vpiRealVar:
+    case vpiStringVar:
+    case vpiTimeVar:
+    case vpiLogicTypespec:
+    case vpiIntTypespec:
+    case vpiLongIntTypespec:
+    case vpiIntegerTypespec:
+    case vpiBitTypespec:
+    case vpiByteTypespec:
+    case vpiRealTypespec:
+    case vpiStringTypespec:
+    case vpiTimeTypespec: {
         AstBasicDTypeKwd keyword = get_kwd_for_type(type);
         auto basic = new AstBasicDType(new FileLine("uhdm"), keyword);
         AstRange* rangeNode = nullptr;
         std::stack<AstRange*> range_stack;
-        visit_one_to_many({vpiRange}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              rangeNode = reinterpret_cast<AstRange*>(node);
-              range_stack.push(rangeNode);
-            });
+        visit_one_to_many({vpiRange}, obj_h, visited, top_nodes, [&](AstNode* node) {
+            rangeNode = reinterpret_cast<AstRange*>(node);
+            range_stack.push(rangeNode);
+        });
         rangeNode = nullptr;
         while (!range_stack.empty()) {
-          if (rangeNode == nullptr) {
-            // Last node serves for basic type
-            rangeNode = range_stack.top();
-            basic->rangep(rangeNode);
-            dtype = basic;
-          } else {
-            // For other levels create a PackedArray
-            rangeNode = range_stack.top();
-            dtype = new AstPackArrayDType(new FileLine("uhdm"),
-                                VFlagChildDType(),
-                                dtype,
-                                rangeNode);
-          }
-          range_stack.pop();
+            if (rangeNode == nullptr) {
+                // Last node serves for basic type
+                rangeNode = range_stack.top();
+                basic->rangep(rangeNode);
+                dtype = basic;
+            } else {
+                // For other levels create a PackedArray
+                rangeNode = range_stack.top();
+                dtype = new AstPackArrayDType(new FileLine("uhdm"), VFlagChildDType(), dtype,
+                                              rangeNode);
+            }
+            range_stack.pop();
         }
-        if (dtype == nullptr) {
-          dtype = basic;
-        }
+        if (dtype == nullptr) { dtype = basic; }
         break;
-      }
-      case vpiEnumNet:
-      case vpiStructNet:
-      case vpiEnumVar:
-      case vpiEnumTypespec:
-      case vpiStructTypespec:
-      case vpiStructVar:
-      case vpiUnionTypespec: {
+    }
+    case vpiEnumNet:
+    case vpiStructNet:
+    case vpiEnumVar:
+    case vpiEnumTypespec:
+    case vpiStructTypespec:
+    case vpiStructVar:
+    case vpiUnionTypespec: {
         std::string type_string;
-        const uhdm_handle* const handle = (const uhdm_handle*) obj_h;
-        const UHDM::BaseClass* const object = (const UHDM::BaseClass*) handle->object;
+        const uhdm_handle* const handle = (const uhdm_handle*)obj_h;
+        const UHDM::BaseClass* const object = (const UHDM::BaseClass*)handle->object;
         std::string type_name = "";
-        if (auto s = vpi_get_str(vpiName, obj_h)) {
-          type_name = s;
-        }
+        if (auto s = vpi_get_str(vpiName, obj_h)) { type_name = s; }
         sanitize_str(type_name);
         if (visited_types.find(object) != visited_types.end()) {
-          type_string = visited_types[object];
-          size_t delimiter_pos = type_string.find("::");
-          if (delimiter_pos == string::npos) {
-            UINFO(7, "No package prefix found, creating ref" << std::endl);
-            dtype = new AstRefDType(new FileLine("uhdm"),
-                                    type_string);
-          } else {
-            auto classpackageName = type_string.substr(0, delimiter_pos);
-            auto type_name = type_string.substr(delimiter_pos + 2, type_string.length());
-            UINFO(7, "Found package prefix: " << classpackageName << std::endl);
-            // If we are in the same package - do not create reference,
-            // as it will confuse Verilator
-            if (classpackageName == package_prefix.substr(0, package_prefix.length()-2)) {
-              UINFO(7, "In the same package, creating simple ref" << std::endl);
-              dtype = new AstRefDType(new FileLine("uhdm"),
-                                      type_name);
+            type_string = visited_types[object];
+            size_t delimiter_pos = type_string.find("::");
+            if (delimiter_pos == string::npos) {
+                UINFO(7, "No package prefix found, creating ref" << std::endl);
+                dtype = new AstRefDType(new FileLine("uhdm"), type_string);
             } else {
-              UINFO(7, "Creating ClassOrPackageRef" << std::endl);
-              AstPackage* classpackagep = nullptr;
-              auto it = package_map.find(classpackageName);
-              if (it != package_map.end()) {
-                classpackagep = it->second;
-              }
-              AstNode* classpackageref = new AstClassOrPackageRef(new FileLine("uhdm"),
-                  classpackageName,
-                  classpackagep,
-                  nullptr);
-              m_symp->nextId(classpackagep);
-              dtype = new AstRefDType(new FileLine("uhdm"),
-                                      type_name,
-                                      classpackageref,
-                                      nullptr);
+                auto classpackageName = type_string.substr(0, delimiter_pos);
+                auto type_name = type_string.substr(delimiter_pos + 2, type_string.length());
+                UINFO(7, "Found package prefix: " << classpackageName << std::endl);
+                // If we are in the same package - do not create reference,
+                // as it will confuse Verilator
+                if (classpackageName == package_prefix.substr(0, package_prefix.length() - 2)) {
+                    UINFO(7, "In the same package, creating simple ref" << std::endl);
+                    dtype = new AstRefDType(new FileLine("uhdm"), type_name);
+                } else {
+                    UINFO(7, "Creating ClassOrPackageRef" << std::endl);
+                    AstPackage* classpackagep = nullptr;
+                    auto it = package_map.find(classpackageName);
+                    if (it != package_map.end()) { classpackagep = it->second; }
+                    AstNode* classpackageref = new AstClassOrPackageRef(
+                        new FileLine("uhdm"), classpackageName, classpackagep, nullptr);
+                    m_symp->nextId(classpackagep);
+                    dtype = new AstRefDType(new FileLine("uhdm"), type_name, classpackageref,
+                                            nullptr);
+                }
             }
-          }
         } else if (type_name != "") {
-          // Type not found or object pointer mismatch, but let's try to create a reference
-          // to be resolved later
-          // Simple reference only, prefix is not stored in name
-          UINFO(7, "No match found, creating ref to name" << type_name << std::endl);
-          dtype = new AstRefDType(new FileLine("uhdm"),
-                                  type_name);
+            // Type not found or object pointer mismatch, but let's try to create a reference
+            // to be resolved later
+            // Simple reference only, prefix is not stored in name
+            UINFO(7, "No match found, creating ref to name" << type_name << std::endl);
+            dtype = new AstRefDType(new FileLine("uhdm"), type_name);
         } else {
-          // Typedefed types were visited earlier, probably anonymous struct
-          // Get the typespec here
-          UINFO(7, "Encountered anonymous struct");
-          AstNode* typespec_p = visit_object(obj_h, visited, top_nodes);
-          dtype = typespec_p->getChildDTypep()->cloneTree(false);
+            // Typedefed types were visited earlier, probably anonymous struct
+            // Get the typespec here
+            UINFO(7, "Encountered anonymous struct");
+            AstNode* typespec_p = visit_object(obj_h, visited, top_nodes);
+            dtype = typespec_p->getChildDTypep()->cloneTree(false);
         }
         break;
-      }
-      case vpiPackedArrayNet:
-      case vpiPackedArrayVar: {
+    }
+    case vpiPackedArrayNet:
+    case vpiPackedArrayVar: {
         // Get the typespec
         vpiHandle element_h;
         auto itr = vpi_iterate(vpiElement, obj_h);
-        while (vpiHandle vpi_child_obj = vpi_scan(itr) ) {
-          // Expect all elements to be the same - grab just one
-          element_h = vpi_child_obj;
+        while (vpiHandle vpi_child_obj = vpi_scan(itr)) {
+            // Expect all elements to be the same - grab just one
+            element_h = vpi_child_obj;
         }
         auto typespec_h = vpi_handle(vpiTypespec, element_h);
         if (typespec_h) {
-          dtype = getDType(element_h, visited, top_nodes);
+            dtype = getDType(element_h, visited, top_nodes);
         } else {
-          v3error("Missing typespec for unpacked/packed_array_var");
+            v3error("Missing typespec for unpacked/packed_array_var");
         }
         AstRange* rangep = nullptr;
 
         visit_one_to_many({vpiRange}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              rangep = reinterpret_cast<AstRange*>(node);
-            });
+                          [&](AstNode* node) { rangep = reinterpret_cast<AstRange*>(node); });
 
-        dtype = new AstPackArrayDType(new FileLine("uhdm"),
-                                      VFlagChildDType(),
-                                      dtype,
-                                      rangep);
+        dtype = new AstPackArrayDType(new FileLine("uhdm"), VFlagChildDType(), dtype, rangep);
         break;
-      }
-      case vpiArrayVar: {
+    }
+    case vpiArrayVar: {
         auto array_type = vpi_get(vpiArrayType, obj_h);
         // todo: static/dynamic/assoc/queue
         auto rand_type = vpi_get(vpiRandType, obj_h);
@@ -484,67 +450,55 @@ namespace UhdmAst {
         AstNodeDType* element_dtype = nullptr;
 
         vpiHandle itr = vpi_iterate(vpiReg, obj_h);
-        while (vpiHandle member_h = vpi_scan(itr) ) {
-          std::string type_name;
-          auto type_h = vpi_handle(vpiTypespec, member_h);
-          if (type_h) {
-            element_dtype = getDType(type_h, visited, top_nodes);
-          }
-          vpi_free_object(member_h);
+        while (vpiHandle member_h = vpi_scan(itr)) {
+            std::string type_name;
+            auto type_h = vpi_handle(vpiTypespec, member_h);
+            if (type_h) { element_dtype = getDType(type_h, visited, top_nodes); }
+            vpi_free_object(member_h);
         }
         vpi_free_object(itr);
 
         AstRange* range = nullptr;
-        visit_one_to_many({vpiRange}, obj_h, visited, top_nodes,
-            [&](AstNode* item) {
-              if (item != nullptr) {
-                range = reinterpret_cast<AstRange*>(item);
-              }
-            });
-        dtype = new AstUnpackArrayDType(new FileLine("uhdm"),
-                                        VFlagChildDType(),
-                                        element_dtype,
+        visit_one_to_many({vpiRange}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item != nullptr) { range = reinterpret_cast<AstRange*>(item); }
+        });
+        dtype = new AstUnpackArrayDType(new FileLine("uhdm"), VFlagChildDType(), element_dtype,
                                         range);
         break;
-      }
-      case vpiArrayNet: {
+    }
+    case vpiArrayNet: {
         AstRange* unpacked_range = nullptr;
         AstNodeDType* subDTypep = nullptr;
 
         vpiHandle itr = vpi_iterate(vpiNet, obj_h);
-        while (vpiHandle vpi_child_obj = vpi_scan(itr) ) {
-          subDTypep = getDType(vpi_child_obj, visited, top_nodes);
-          vpi_free_object(vpi_child_obj);
+        while (vpiHandle vpi_child_obj = vpi_scan(itr)) {
+            subDTypep = getDType(vpi_child_obj, visited, top_nodes);
+            vpi_free_object(vpi_child_obj);
         }
         vpi_free_object(itr);
 
-        visit_one_to_many({vpiRange}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              if ((node != nullptr) && (unpacked_range == nullptr)) {
+        visit_one_to_many({vpiRange}, obj_h, visited, top_nodes, [&](AstNode* node) {
+            if ((node != nullptr) && (unpacked_range == nullptr)) {
                 unpacked_range = reinterpret_cast<AstRange*>(node);
-              }
-            });
+            }
+        });
 
         if ((subDTypep == nullptr) || (unpacked_range == nullptr)) {
-          v3error("Missing net and/or unpacked range");
-          return nullptr;
+            v3error("Missing net and/or unpacked range");
+            return nullptr;
         }
 
-        dtype =
-          new AstUnpackArrayDType(new FileLine("uhdm"), VFlagChildDType(),
-                                  subDTypep, unpacked_range);
+        dtype = new AstUnpackArrayDType(new FileLine("uhdm"), VFlagChildDType(), subDTypep,
+                                        unpacked_range);
         break;
-      }
-      default:
-        v3error("Unknown object type: " << UHDM::VpiTypeName(obj_h));
+    }
+    default: v3error("Unknown object type: " << UHDM::VpiTypeName(obj_h));
     }
     return dtype;
-  }
+}
 
-
-  AstNode* visit_object (vpiHandle obj_h,
-        std::set<const UHDM::BaseClass*> visited,
-        std::map<std::string, AstNodeModule*>* top_nodes) {
+AstNode* visit_object(vpiHandle obj_h, std::set<const UHDM::BaseClass*> visited,
+                      std::map<std::string, AstNodeModule*>* top_nodes) {
     // Will keep current node
     AstNode* node = nullptr;
 
@@ -558,2295 +512,1955 @@ namespace UhdmAst {
 
     auto file_name = vpi_get_str(vpiFile, obj_h);
     if (auto s = vpi_get_str(vpiFullName, obj_h)) {
-      fullObjectName = s;
-      sanitize_str(fullObjectName);
+        fullObjectName = s;
+        sanitize_str(fullObjectName);
     }
     for (auto name : {vpiName, vpiFullName, vpiDefName}) {
-      if (auto s = vpi_get_str(name, obj_h)) {
-        objectName = s;
-        sanitize_str(objectName);
-        break;
-      }
+        if (auto s = vpi_get_str(name, obj_h)) {
+            objectName = s;
+            sanitize_str(objectName);
+            break;
+        }
     }
-    if (unsigned int l = vpi_get(vpiLineNo, obj_h)) {
-      lineNo = l;
-    }
+    if (unsigned int l = vpi_get(vpiLineNo, obj_h)) { lineNo = l; }
 
     const unsigned int currentLine = vpi_get(vpiLineNo, obj_h);
     const unsigned int objectType = vpi_get(vpiType, obj_h);
-    UINFO(6, "Object: " << objectName
-              << " of type " << objectType
-              << " (" << UHDM::VpiTypeName(obj_h) << ")"
-              << " @ " << currentLine
-              << " : " << (file_name != 0 ? file_name : "?")
-              << std::endl);
-    if (file_name) {
-      coverage_set.insert({file_name, currentLine, UHDM::VpiTypeName(obj_h)});
-    }
+    UINFO(6, "Object: " << objectName << " of type " << objectType << " ("
+                        << UHDM::VpiTypeName(obj_h) << ")"
+                        << " @ " << currentLine << " : " << (file_name != 0 ? file_name : "?")
+                        << std::endl);
+    if (file_name) { coverage_set.insert({file_name, currentLine, UHDM::VpiTypeName(obj_h)}); }
 
     bool alreadyVisited = false;
-    const uhdm_handle* const handle = (const uhdm_handle*) obj_h;
-    const UHDM::BaseClass* const object = (const UHDM::BaseClass*) handle->object;
-    if (visited.find(object) != visited.end()) {
-      alreadyVisited = true;
-    }
+    const uhdm_handle* const handle = (const uhdm_handle*)obj_h;
+    const UHDM::BaseClass* const object = (const UHDM::BaseClass*)handle->object;
+    if (visited.find(object) != visited.end()) { alreadyVisited = true; }
     visited.insert(object);
     if (alreadyVisited) {
-      UINFO(6, "Object " << objectName << " was already visited" << std::endl);
-      return node;
+        UINFO(6, "Object " << objectName << " was already visited" << std::endl);
+        return node;
     }
 
-    switch(objectType) {
-      case vpiDesign: {
+    switch (objectType) {
+    case vpiDesign: {
 
-        visit_one_to_many({UHDM::uhdmallInterfaces, UHDM::uhdmtopModules},
-            obj_h,
-            visited,
-            top_nodes,
-            [&](AstNode* module) {
-              if (module != nullptr) {
-                node = module;
-              }
-            });
+        visit_one_to_many({UHDM::uhdmallInterfaces, UHDM::uhdmtopModules}, obj_h, visited,
+                          top_nodes, [&](AstNode* module) {
+                              if (module != nullptr) { node = module; }
+                          });
         return node;
-      }
-      case vpiPackage: {
+    }
+    case vpiPackage: {
         auto* package = new AstPackage(new FileLine(objectName), objectName);
         package->inLibrary(true);
         package_prefix += objectName + "::";
         m_symp->pushNew(package);
-        visit_one_to_many({
-            vpiTypedef,
-            vpiParameter,
-            vpiParamAssign,
-            vpiProgram,
-            vpiProgramArray,
-            vpiTaskFunc,
-            vpiSpecParam,
-            vpiAssertion,
+        visit_one_to_many(
+            {
+                vpiTypedef,
+                vpiParameter,
+                vpiParamAssign,
+                vpiProgram,
+                vpiProgramArray,
+                vpiTaskFunc,
+                vpiSpecParam,
+                vpiAssertion,
             },
-            obj_h,
-            visited,
-            top_nodes,
-            [&](AstNode* item) {
-              if (item != nullptr) {
-                package->addStmtp(item);
-              }
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (item != nullptr) { package->addStmtp(item); }
             });
         m_symp->popScope(package);
-        package_prefix = package_prefix.substr(0,
-            package_prefix.length() - (objectName.length() + 2));
+        package_prefix
+            = package_prefix.substr(0, package_prefix.length() - (objectName.length() + 2));
 
         package_map[objectName] = package;
         return package;
-      }
-      case vpiPort: {
+    }
+    case vpiPort: {
         static unsigned numPorts;
-        AstPort *port = nullptr;
-        AstVar *var = nullptr;
+        AstPort* port = nullptr;
+        AstVar* var = nullptr;
 
         AstNodeDType* dtype = nullptr;
         auto parent_h = vpi_handle(vpiParent, obj_h);
         std::string netName = "";
-        for (auto net : {vpiNet,
-                         vpiNetArray,
-                         vpiArrayVar,
-                         vpiArrayNet,
-                         vpiVariables
-                         }) {
-          vpiHandle itr = vpi_iterate(net, parent_h);
-          while (vpiHandle vpi_child_obj = vpi_scan(itr) ) {
-            if (auto s = vpi_get_str(vpiName, vpi_child_obj)) {
-              netName = s;
-              sanitize_str(netName);
-              UINFO(7, "Net name is " << netName << std::endl);
+        for (auto net : {vpiNet, vpiNetArray, vpiArrayVar, vpiArrayNet, vpiVariables}) {
+            vpiHandle itr = vpi_iterate(net, parent_h);
+            while (vpiHandle vpi_child_obj = vpi_scan(itr)) {
+                if (auto s = vpi_get_str(vpiName, vpi_child_obj)) {
+                    netName = s;
+                    sanitize_str(netName);
+                    UINFO(7, "Net name is " << netName << std::endl);
+                }
+                if (netName == objectName) {
+                    UINFO(7, "Found matching net for " << objectName << std::endl);
+                    dtype = getDType(vpi_child_obj, visited, top_nodes);
+                    break;
+                }
+                vpi_free_object(vpi_child_obj);
             }
-            if (netName == objectName) {
-              UINFO(7, "Found matching net for " << objectName << std::endl);
-              dtype = getDType(vpi_child_obj, visited, top_nodes);
-              break;
-            }
-            vpi_free_object(vpi_child_obj);
-          }
-          vpi_free_object(itr);
+            vpi_free_object(itr);
         }
         if (dtype == nullptr) {
-          // If no matching net was found, get info from port node connections
-          // This is the case for interface ports
-          dtype = getDType(obj_h, visited, top_nodes);
+            // If no matching net was found, get info from port node connections
+            // This is the case for interface ports
+            dtype = getDType(obj_h, visited, top_nodes);
         }
         if (VN_IS(dtype, IfaceRefDType)) {
-          var = new AstVar(new FileLine("uhdm"),
-                           AstVarType::IFACEREF,
-                           objectName,
-                           VFlagChildDType(),
-                           dtype);
+            var = new AstVar(new FileLine("uhdm"), AstVarType::IFACEREF, objectName,
+                             VFlagChildDType(), dtype);
         } else {
-          var = new AstVar(new FileLine("uhdm"),
-                           AstVarType::PORT,
-                           objectName,
-                           VFlagChildDType(),
-                           dtype);
+            var = new AstVar(new FileLine("uhdm"), AstVarType::PORT, objectName, VFlagChildDType(),
+                             dtype);
 
-          if (const int n = vpi_get(vpiDirection, obj_h)) {
-            v3info(
-                "Got direction for " << objectName);
-            if (n == vpiInput) {
-              var->declDirection(VDirection::INPUT);
-              var->direction(VDirection::INPUT);
-              var->varType(AstVarType::PORT);
-            } else if (n == vpiOutput) {
-              var->declDirection(VDirection::OUTPUT);
-              var->direction(VDirection::OUTPUT);
-              var->varType(AstVarType::PORT);
-            } else if (n == vpiInout) {
-              var->declDirection(VDirection::INOUT);
-              var->direction(VDirection::INOUT);
+            if (const int n = vpi_get(vpiDirection, obj_h)) {
+                v3info("Got direction for " << objectName);
+                if (n == vpiInput) {
+                    var->declDirection(VDirection::INPUT);
+                    var->direction(VDirection::INPUT);
+                    var->varType(AstVarType::PORT);
+                } else if (n == vpiOutput) {
+                    var->declDirection(VDirection::OUTPUT);
+                    var->direction(VDirection::OUTPUT);
+                    var->varType(AstVarType::PORT);
+                } else if (n == vpiInout) {
+                    var->declDirection(VDirection::INOUT);
+                    var->direction(VDirection::INOUT);
+                }
+            } else {
+                v3info("Got no direction for " << objectName << ", skipping");
+                return nullptr;
             }
-          } else {
-            v3info("Got no direction for " << objectName << ", skipping");
-            return nullptr;
-          }
         }
 
         port = new AstPort(new FileLine("uhdm"), ++numPorts, objectName);
         port->addNextNull(var);
 
-        if (v3Global.opt.trace()) {
-            var->trace(true);
-        }
+        if (v3Global.opt.trace()) { var->trace(true); }
 
         return port;
-      }
-      case UHDM::uhdmimport: {
-          AstPackage* packagep = nullptr;
-          auto it = package_map.find(objectName);
-          if (it != package_map.end()) {
-            packagep = it->second;
-          }
-          if (packagep != nullptr) {
+    }
+    case UHDM::uhdmimport: {
+        AstPackage* packagep = nullptr;
+        auto it = package_map.find(objectName);
+        if (it != package_map.end()) { packagep = it->second; }
+        if (packagep != nullptr) {
             std::string symbol_name;
             vpiHandle imported_name = vpi_handle(vpiImport, obj_h);
             if (imported_name) {
-              s_vpi_value val;
-              vpi_get_value(imported_name, &val);
-              symbol_name = val.value.str;
+                s_vpi_value val;
+                vpi_get_value(imported_name, &val);
+                symbol_name = val.value.str;
             }
-            auto* package_import = new AstPackageImport(new FileLine("uhdm"),
-                                                    packagep,
-                                                    symbol_name);
+            auto* package_import
+                = new AstPackageImport(new FileLine("uhdm"), packagep, symbol_name);
             m_symp->importItem(packagep, symbol_name);
             return package_import;
-          }
-      }
-      case vpiModule: {
+        }
+    }
+    case vpiModule: {
 
         std::string modType = vpi_get_str(vpiDefName, obj_h);
         sanitize_str(modType);
 
         std::string name = objectName;
-        AstModule *module;
+        AstModule* module;
 
         // Check if we have encountered this object before
         auto it = partialModules.find(modType);
         if (it != partialModules.end()) {
-          // Was created before, fill missing
-          module = reinterpret_cast<AstModule*>(it->second);
-          AstModule* full_module = nullptr;
-          if (objectName != modType) {
-            static int module_counter;
-            // Not a top module, create separate node with proper params
-            module = module->cloneTree(false);
-            // Use more specific name
-            name = modType + "_" + objectName + std::to_string(module_counter++);
-          }
-          module->name(name);
-          m_symp->pushNew(module);
-          visit_one_to_many({
-              vpiPort,
-              vpiInterface,
-              vpiInterfaceArray,
-              vpiProcess,
-              vpiContAssign,
-              vpiModule,
-              vpiModuleArray,
-              vpiPrimitive,
-              vpiPrimitiveArray,
-              vpiModPath,
-              vpiTchk,
-              vpiDefParam,
-              vpiIODecl,
-              vpiAliasStmt,
-              vpiClockingBlock,
-              vpiNet,
-              vpiGenScopeArray,
-              vpiArrayNet,
+            // Was created before, fill missing
+            module = reinterpret_cast<AstModule*>(it->second);
+            AstModule* full_module = nullptr;
+            if (objectName != modType) {
+                static int module_counter;
+                // Not a top module, create separate node with proper params
+                module = module->cloneTree(false);
+                // Use more specific name
+                name = modType + "_" + objectName + std::to_string(module_counter++);
+            }
+            module->name(name);
+            m_symp->pushNew(module);
+            visit_one_to_many(
+                {
+                    vpiPort,
+                    vpiInterface,
+                    vpiInterfaceArray,
+                    vpiProcess,
+                    vpiContAssign,
+                    vpiModule,
+                    vpiModuleArray,
+                    vpiPrimitive,
+                    vpiPrimitiveArray,
+                    vpiModPath,
+                    vpiTchk,
+                    vpiDefParam,
+                    vpiIODecl,
+                    vpiAliasStmt,
+                    vpiClockingBlock,
+                    vpiNet,
+                    vpiGenScopeArray,
+                    vpiArrayNet,
 
-              // from vpiInstance
-              vpiProgram,
-              vpiProgramArray,
-              vpiTaskFunc,
-              vpiSpecParam,
-              vpiAssertion,
-              //vpiClassDefn,
+                    // from vpiInstance
+                    vpiProgram,
+                    vpiProgramArray,
+                    vpiTaskFunc,
+                    vpiSpecParam,
+                    vpiAssertion,
+                    // vpiClassDefn,
 
-              // from vpiScope
-              vpiPropertyDecl,
-              vpiSequenceDecl,
-              vpiConcurrentAssertions,
-              vpiNamedEvent,
-              vpiNamedEventArray,
-              vpiVariables,
-              vpiVirtualInterfaceVar,
-              vpiReg,
-              vpiRegArray,
-              vpiMemory,
-              vpiInternalScope,
-              vpiImport,
-              vpiAttribute,
-              },
-              obj_h,
-              visited,
-              top_nodes,
-              [&](AstNode* node){
-                if (node != nullptr)
-                  module->addStmtp(node);
-              });
-          (*top_nodes)[name] = module;
-          m_symp->popScope(module);
+                    // from vpiScope
+                    vpiPropertyDecl,
+                    vpiSequenceDecl,
+                    vpiConcurrentAssertions,
+                    vpiNamedEvent,
+                    vpiNamedEventArray,
+                    vpiVariables,
+                    vpiVirtualInterfaceVar,
+                    vpiReg,
+                    vpiRegArray,
+                    vpiMemory,
+                    vpiInternalScope,
+                    vpiImport,
+                    vpiAttribute,
+                },
+                obj_h, visited, top_nodes, [&](AstNode* node) {
+                    if (node != nullptr) module->addStmtp(node);
+                });
+            (*top_nodes)[name] = module;
+            m_symp->popScope(module);
         } else {
-          // Encountered for the first time
-          module = new AstModule(new FileLine(modType), modType);
-          visit_one_to_many({
-              vpiTypedef,  // Keep this before parameters
-              vpiModule,
-              vpiContAssign,
-              vpiParamAssign,
-              vpiParameter,
-              vpiProcess,
-              vpiTaskFunc,
-              },
-              obj_h,
-              visited,
-              top_nodes,
-              [&](AstNode* node){
-                if (node != nullptr)
-                  module->addStmtp(node);
-              });
-          visit_one_to_many({
-              vpiPort,
-              vpiNet,
-              vpiParameter,
-              vpiParamAssign,
-              },
-              obj_h,
-              visited,
-              top_nodes,
-              [&](AstNode* node){
-                // ignore, currently would create duplicate nodes
-                //TODO: Revisit this handling
-              });
-          (partialModules)[module->name()] = module;
+            // Encountered for the first time
+            module = new AstModule(new FileLine(modType), modType);
+            visit_one_to_many(
+                {
+                    vpiTypedef,  // Keep this before parameters
+                    vpiModule,
+                    vpiContAssign,
+                    vpiParamAssign,
+                    vpiParameter,
+                    vpiProcess,
+                    vpiTaskFunc,
+                },
+                obj_h, visited, top_nodes, [&](AstNode* node) {
+                    if (node != nullptr) module->addStmtp(node);
+                });
+            visit_one_to_many(
+                {
+                    vpiPort,
+                    vpiNet,
+                    vpiParameter,
+                    vpiParamAssign,
+                },
+                obj_h, visited, top_nodes, [&](AstNode* node) {
+                    // ignore, currently would create duplicate nodes
+                    // TODO: Revisit this handling
+                });
+            (partialModules)[module->name()] = module;
         }
 
         if (objectName != modType) {
-          // Not a top module, create instance
-          AstPin *modPins = nullptr;
-          AstPin *modParams = nullptr;
+            // Not a top module, create instance
+            AstPin* modPins = nullptr;
+            AstPin* modParams = nullptr;
 
-          // Get port assignments
-          vpiHandle itr = vpi_iterate(vpiPort, obj_h);
-          int np = 0;
-          while (vpiHandle vpi_child_obj = vpi_scan(itr) ) {
-            vpiHandle highConn = vpi_handle(vpiHighConn, vpi_child_obj);
-            std::string portName = vpi_get_str(vpiName, vpi_child_obj);
-            sanitize_str(portName);
-            AstNode* ref = nullptr;
-            if (highConn) {
-              ref = visit_object(highConn, visited, top_nodes);
+            // Get port assignments
+            vpiHandle itr = vpi_iterate(vpiPort, obj_h);
+            int np = 0;
+            while (vpiHandle vpi_child_obj = vpi_scan(itr)) {
+                vpiHandle highConn = vpi_handle(vpiHighConn, vpi_child_obj);
+                std::string portName = vpi_get_str(vpiName, vpi_child_obj);
+                sanitize_str(portName);
+                AstNode* ref = nullptr;
+                if (highConn) { ref = visit_object(highConn, visited, top_nodes); }
+                AstPin* pin = new AstPin(new FileLine("uhdm"), ++np, portName, ref);
+                if (!modPins)
+                    modPins = pin;
+                else
+                    modPins->addNextNull(pin);
+
+                vpi_free_object(vpi_child_obj);
             }
-            AstPin *pin = new AstPin(new FileLine("uhdm"), ++np, portName, ref);
-            if (!modPins)
-                modPins = pin;
-            else
-                modPins->addNextNull(pin);
+            vpi_free_object(itr);
 
-            vpi_free_object(vpi_child_obj);
-          }
-          vpi_free_object(itr);
-
-          // Get parameter assignments
-          itr = vpi_iterate(vpiParamAssign, obj_h);
-          std::set<std::string> parameter_set;
-          while (vpiHandle vpi_child_obj = vpi_scan(itr) ) {
-            vpiHandle param_handle = vpi_handle(vpiLhs, vpi_child_obj);
-            std::string param_name = vpi_get_str(vpiName, param_handle);
-            sanitize_str(param_name);
-            UINFO(3, "Got parameter (pin) " << param_name << std::endl);
-            auto is_local = vpi_get(vpiLocalParam, param_handle);
-            AstNode* value = nullptr;
-            // Try to construct complex expression
-            visit_one_to_one({vpiRhs}, vpi_child_obj, visited, top_nodes,
-                [&](AstNode* node){
-                  if (node != nullptr)
-                    value = node;
-                  else
-                    v3error("No value for parameter: " << param_name);
+            // Get parameter assignments
+            itr = vpi_iterate(vpiParamAssign, obj_h);
+            std::set<std::string> parameter_set;
+            while (vpiHandle vpi_child_obj = vpi_scan(itr)) {
+                vpiHandle param_handle = vpi_handle(vpiLhs, vpi_child_obj);
+                std::string param_name = vpi_get_str(vpiName, param_handle);
+                sanitize_str(param_name);
+                UINFO(3, "Got parameter (pin) " << param_name << std::endl);
+                auto is_local = vpi_get(vpiLocalParam, param_handle);
+                AstNode* value = nullptr;
+                // Try to construct complex expression
+                visit_one_to_one({vpiRhs}, vpi_child_obj, visited, top_nodes, [&](AstNode* node) {
+                    if (node != nullptr)
+                        value = node;
+                    else
+                        v3error("No value for parameter: " << param_name);
                 });
-            if (is_local) {
-              // Skip local parameters
-              UINFO(3, "Skipping local parameter (pin) " << param_name << std::endl);
-              continue;
+                if (is_local) {
+                    // Skip local parameters
+                    UINFO(3, "Skipping local parameter (pin) " << param_name << std::endl);
+                    continue;
+                }
+                if (is_imported(param_handle)) {
+                    // Skip imported parameters when creating cells
+                    UINFO(3, "Skipping imported parameter (pin) " << param_name << std::endl);
+                    continue;
+                }
+                if (parameter_set.find(param_name) == parameter_set.end()) {
+                    // Although those are parameters, they are stored as pins
+                    AstPin* pin = new AstPin(new FileLine("uhdm"), ++np, param_name, value);
+                    if (!modParams)
+                        modParams = pin;
+                    else
+                        modParams->addNextNull(pin);
+                    parameter_set.insert(param_name);
+                } else {
+                    // Duplicate
+                    UINFO(3, "Duplicate parameter assignment: " << param_name << " in "
+                                                                << objectName << std::endl);
+                    continue;
+                }
+                vpi_free_object(vpi_child_obj);
             }
-            if (is_imported(param_handle)) {
-              // Skip imported parameters when creating cells
-              UINFO(3, "Skipping imported parameter (pin) " << param_name << std::endl);
-              continue;
-            }
-            if (parameter_set.find(param_name) == parameter_set.end()) {
-              // Although those are parameters, they are stored as pins
-              AstPin *pin = new AstPin(new FileLine("uhdm"), ++np, param_name, value);
-              if (!modParams)
-                  modParams = pin;
-              else
-                  modParams->addNextNull(pin);
-              parameter_set.insert(param_name);
-            } else {
-              // Duplicate
-              UINFO(3, "Duplicate parameter assignment: " << param_name 
-                      << " in " << objectName <<std::endl );
-              continue;
-            }
-            vpi_free_object(vpi_child_obj);
-          }
-          vpi_free_object(itr);
-          std::string fullname = vpi_get_str(vpiFullName, obj_h);
-          sanitize_str(fullname);
-          UINFO(8, "Adding cell " << fullname << std::endl);
-          AstCell *cell = new AstCell(new FileLine("uhdm"), new FileLine("uhdm"),
-              objectName, name, modPins, modParams, nullptr);
-          return cell;
+            vpi_free_object(itr);
+            std::string fullname = vpi_get_str(vpiFullName, obj_h);
+            sanitize_str(fullname);
+            UINFO(8, "Adding cell " << fullname << std::endl);
+            AstCell* cell = new AstCell(new FileLine("uhdm"), new FileLine("uhdm"), objectName,
+                                        name, modPins, modParams, nullptr);
+            return cell;
         }
         break;
-      }
-      case vpiAssignment:
-      case vpiAssignStmt:
-      case vpiContAssign: {
+    }
+    case vpiAssignment:
+    case vpiAssignStmt:
+    case vpiContAssign: {
         AstNode* lvalue = nullptr;
         AstNode* rvalue = nullptr;
 
         // Right
-        visit_one_to_one({vpiRhs},
-            obj_h,
-            visited,
-            top_nodes,
-            [&](AstNode* child){
-              rvalue = child;
-            });
+        visit_one_to_one({vpiRhs}, obj_h, visited, top_nodes,
+                         [&](AstNode* child) { rvalue = child; });
 
         // Left
-        visit_one_to_one({vpiLhs},
-            obj_h,
-            visited,
-            top_nodes,
-            [&](AstNode* child){
-              lvalue = child;
-            });
+        visit_one_to_one({vpiLhs}, obj_h, visited, top_nodes,
+                         [&](AstNode* child) { lvalue = child; });
 
         if (rvalue != nullptr && rvalue->type() == AstType::en::atFOpen) {
-          // Not really an assignment, AstFOpen node takes care of the lhs
-          return rvalue;
+            // Not really an assignment, AstFOpen node takes care of the lhs
+            return rvalue;
         }
         if (lvalue && rvalue) {
-          if (objectType == vpiAssignment) {
-            auto blocking = vpi_get(vpiBlocking, obj_h);
-            if (blocking) {
-              return new AstAssign(new FileLine("uhdm"), lvalue, rvalue);
+            if (objectType == vpiAssignment) {
+                auto blocking = vpi_get(vpiBlocking, obj_h);
+                if (blocking) {
+                    return new AstAssign(new FileLine("uhdm"), lvalue, rvalue);
+                } else {
+                    return new AstAssignDly(new FileLine("uhdm"), lvalue, rvalue);
+                }
             } else {
-              return new AstAssignDly(new FileLine("uhdm"), lvalue, rvalue);
+                AstNode* assign;
+                if (lvalue->type() == AstType::en::atVar) {
+                    // This is not a true assignment
+                    // Set initial value to a variable and return it
+                    AstVar* var = static_cast<AstVar*>(lvalue);
+                    var->valuep(rvalue);
+                    return var;
+                } else {
+                    if (objectType == vpiContAssign)
+                        assign = new AstAssignW(new FileLine("uhdm"), lvalue, rvalue);
+                    else
+                        assign = new AstAssign(new FileLine("uhdm"), lvalue, rvalue);
+                    return assign;
+                }
             }
-          } else {
-            AstNode* assign;
-            if (lvalue->type() == AstType::en::atVar) {
-              // This is not a true assignment
-              // Set initial value to a variable and return it
-              AstVar* var = static_cast<AstVar*>(lvalue);
-              var->valuep(rvalue);
-              return var;
-            } else {
-              if (objectType == vpiContAssign)
-                assign = new AstAssignW(new FileLine("uhdm"), lvalue, rvalue);
-              else
-                assign = new AstAssign(new FileLine("uhdm"), lvalue, rvalue);
-              return assign;
-            }
-          }
         }
         break;
-      }
-      case vpiHierPath: {
+    }
+    case vpiHierPath: {
         AstNode* lhsNode = nullptr;
         AstNode* rhsNode = nullptr;
 
-        visit_one_to_many({vpiActual},
-            obj_h,
-            visited,
-            top_nodes,
-            [&](AstNode* child){
-              if (lhsNode == nullptr) {
+        visit_one_to_many({vpiActual}, obj_h, visited, top_nodes, [&](AstNode* child) {
+            if (lhsNode == nullptr) {
                 lhsNode = child;
-              } else if (rhsNode == nullptr) {
+            } else if (rhsNode == nullptr) {
                 rhsNode = child;
-              } else {
+            } else {
                 v3error("Unexpected node in hier_path");
-              }
-            });
+            }
+        });
 
         return new AstDot(new FileLine("uhdm"), false, lhsNode, rhsNode);
-      }
-      case vpiRefObj: {
+    }
+    case vpiRefObj: {
         size_t dot_pos = objectName.rfind('.');
         if (dot_pos != std::string::npos) {
-          //TODO: Handle >1 dot
-          std::string lhs = objectName.substr(0, dot_pos);
-          std::string rhs = objectName.substr(dot_pos + 1, objectName.length());
-          AstParseRef* lhsNode = new AstParseRef(new FileLine("uhdm"),
-                                                 VParseRefExp::en::PX_TEXT,
-                                                 lhs,
-                                                 nullptr,
-                                                 nullptr);
-          AstParseRef* rhsNode = new AstParseRef(new FileLine("uhdm"),
-                                                 VParseRefExp::en::PX_TEXT,
-                                                 rhs,
-                                                 nullptr,
-                                                 nullptr);
+            // TODO: Handle >1 dot
+            std::string lhs = objectName.substr(0, dot_pos);
+            std::string rhs = objectName.substr(dot_pos + 1, objectName.length());
+            AstParseRef* lhsNode = new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT,
+                                                   lhs, nullptr, nullptr);
+            AstParseRef* rhsNode = new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT,
+                                                   rhs, nullptr, nullptr);
 
-          return new AstDot(new FileLine("uhdm"), false, lhsNode, rhsNode);
+            return new AstDot(new FileLine("uhdm"), false, lhsNode, rhsNode);
         } else {
-          bool isLvalue = false;
-          vpiHandle actual = vpi_handle(vpiActual, obj_h);
-          if (actual) {
-            auto actual_type = vpi_get(vpiType, actual);
-            if (actual_type == vpiPort) {
-              if (const int n = vpi_get(vpiDirection, actual)) {
-                if (n == vpiInput) {
-                  isLvalue = false;
-                } else if (n == vpiOutput) {
-                  isLvalue = true;
-                } else if (n == vpiInout) {
-                  isLvalue = true;
+            bool isLvalue = false;
+            vpiHandle actual = vpi_handle(vpiActual, obj_h);
+            if (actual) {
+                auto actual_type = vpi_get(vpiType, actual);
+                if (actual_type == vpiPort) {
+                    if (const int n = vpi_get(vpiDirection, actual)) {
+                        if (n == vpiInput) {
+                            isLvalue = false;
+                        } else if (n == vpiOutput) {
+                            isLvalue = true;
+                        } else if (n == vpiInout) {
+                            isLvalue = true;
+                        }
+                    }
                 }
-              }
+                vpi_free_object(actual);
             }
-            vpi_free_object(actual);
-          }
-          return new AstParseRef(new FileLine("uhdm"),
-                                                 VParseRefExp::en::PX_TEXT,
-                                                 objectName,
-                                                 nullptr,
-                                                 nullptr);
+            return new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT, objectName,
+                                   nullptr, nullptr);
         }
         break;
-      }
-      case vpiNetArray: {// also defined as vpiArrayNet
+    }
+    case vpiNetArray: {  // also defined as vpiArrayNet
         // vpiNetArray is used for unpacked arrays
         AstVar* vpi_net = nullptr;
-        visit_one_to_many({vpiNet}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              if ((node != nullptr) && (vpi_net == nullptr)) {
+        visit_one_to_many({vpiNet}, obj_h, visited, top_nodes, [&](AstNode* node) {
+            if ((node != nullptr) && (vpi_net == nullptr)) {
                 vpi_net = reinterpret_cast<AstVar*>(node);
-              }
-            });
+            }
+        });
 
         auto dtypep = getDType(obj_h, visited, top_nodes);
-        AstVar* v = new AstVar(new FileLine("uhdm"), vpi_net->varType(),
-                               objectName,
-                               VFlagChildDType(),
-                               dtypep);
+        AstVar* v = new AstVar(new FileLine("uhdm"), vpi_net->varType(), objectName,
+                               VFlagChildDType(), dtypep);
         return v;
-      }
+    }
 
-      case vpiEnumNet:
-      case vpiStructNet:
-      case vpiIntegerNet:
-      case vpiTimeNet:
-      case vpiPackedArrayNet:
-      case vpiLogicNet: {  // also defined as vpiNet
-        AstNodeDType *dtype = nullptr;
+    case vpiEnumNet:
+    case vpiStructNet:
+    case vpiIntegerNet:
+    case vpiTimeNet:
+    case vpiPackedArrayNet:
+    case vpiLogicNet: {  // also defined as vpiNet
+        AstNodeDType* dtype = nullptr;
         AstVarType net_type = AstVarType::VAR;
         AstBasicDTypeKwd dtypeKwd = AstBasicDTypeKwd::LOGIC_IMPLICIT;
         vpiHandle obj_net;
-          dtype = getDType(obj_h, visited, top_nodes);
+        dtype = getDType(obj_h, visited, top_nodes);
 
         if (net_type == AstVarType::UNKNOWN && dtype == nullptr) {
-          // Not set in case above, most likely a "false" port net
-          return nullptr; // Skip this net
+            // Not set in case above, most likely a "false" port net
+            return nullptr;  // Skip this net
         }
 
-        return new AstVar(new FileLine("uhdm"), net_type, objectName,
-                       VFlagChildDType(),
-                       dtype);
-      }
-      case vpiStructVar: {
+        return new AstVar(new FileLine("uhdm"), net_type, objectName, VFlagChildDType(), dtype);
+    }
+    case vpiStructVar: {
         AstNodeDType* dtype = getDType(obj_h, visited, top_nodes);
 
-        auto* v = new AstVar(new FileLine("uhdm"),
-                             AstVarType::VAR,
-                             objectName,
-                             VFlagChildDType(),
+        auto* v = new AstVar(new FileLine("uhdm"), AstVarType::VAR, objectName, VFlagChildDType(),
                              dtype);
         return v;
-      }
-      case vpiParameter:
-      case vpiParamAssign: {
+    }
+    case vpiParameter:
+    case vpiParamAssign: {
         AstVar* parameter = nullptr;
         AstNode* parameter_value = nullptr;
         vpiHandle parameter_h;
 
         if (objectType == vpiParamAssign) {
-          parameter_h = vpi_handle(vpiLhs, obj_h);
-          // Update object name using parameter handle
-          if (auto s = vpi_get_str(vpiName, parameter_h)) {
-            objectName = s;
-            sanitize_str(objectName);
-          }
+            parameter_h = vpi_handle(vpiLhs, obj_h);
+            // Update object name using parameter handle
+            if (auto s = vpi_get_str(vpiName, parameter_h)) {
+                objectName = s;
+                sanitize_str(objectName);
+            }
         } else if (objectType == vpiParameter) {
-          parameter_h = obj_h;
+            parameter_h = obj_h;
         }
         if (is_imported(parameter_h)) {
-          // Skip imported parameters, they will still be visible in their packages
-          UINFO(3, "Skipping imported parameter " << objectName << std::endl);
-          return nullptr;
+            // Skip imported parameters, they will still be visible in their packages
+            UINFO(3, "Skipping imported parameter " << objectName << std::endl);
+            return nullptr;
         }
 
         AstRange* rangeNode = nullptr;
-        visit_one_to_many({vpiRange}, parameter_h, visited, top_nodes,
-            [&](AstNode* node){
-	      if (node)
-	        rangeNode = reinterpret_cast<AstRange*>(node);
-            });
+        visit_one_to_many({vpiRange}, parameter_h, visited, top_nodes, [&](AstNode* node) {
+            if (node) rangeNode = reinterpret_cast<AstRange*>(node);
+        });
 
         AstNodeDType* dtype = nullptr;
         auto typespec_h = vpi_handle(vpiTypespec, parameter_h);
-        if (typespec_h) {
-          dtype = getDType(typespec_h, visited, top_nodes);
-        }
+        if (typespec_h) { dtype = getDType(typespec_h, visited, top_nodes); }
 
         // If no typespec provided assume default
         if (dtype == nullptr) {
-          auto* temp_dtype = new AstBasicDType(new FileLine("uhdm"),
-                                               AstBasicDTypeKwd::LOGIC_IMPLICIT);
-          dtype = temp_dtype;
+            auto* temp_dtype
+                = new AstBasicDType(new FileLine("uhdm"), AstBasicDTypeKwd::LOGIC_IMPLICIT);
+            dtype = temp_dtype;
         }
         if (rangeNode) {
-          dtype = new AstUnpackArrayDType(new FileLine("uhdm"),
-                                          VFlagChildDType(),
-                                          dtype,
-                                          rangeNode);
+            dtype = new AstUnpackArrayDType(new FileLine("uhdm"), VFlagChildDType(), dtype,
+                                            rangeNode);
         }
         AstVarType parameter_type;
         int is_local = 0;
 
         // Get value
         if (objectType == vpiParamAssign) {
-          visit_one_to_one({vpiRhs}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                parameter_value = node;
-              });
-          is_local = vpi_get(vpiLocalParam, vpi_handle(vpiLhs, obj_h));
+            visit_one_to_one({vpiRhs}, obj_h, visited, top_nodes,
+                             [&](AstNode* node) { parameter_value = node; });
+            is_local = vpi_get(vpiLocalParam, vpi_handle(vpiLhs, obj_h));
         } else if (objectType == vpiParameter) {
-          parameter_value = get_value_as_node(obj_h);
-          is_local = vpi_get(vpiLocalParam, obj_h);
+            parameter_value = get_value_as_node(obj_h);
+            is_local = vpi_get(vpiLocalParam, obj_h);
         }
 
         if (is_local)
-          parameter_type = AstVarType::LPARAM;
+            parameter_type = AstVarType::LPARAM;
         else
-          parameter_type = AstVarType::GPARAM;
-
+            parameter_type = AstVarType::GPARAM;
 
         // if no value: bail
         if (parameter_value == nullptr) {
-          return nullptr;
+            return nullptr;
         } else {
-          parameter = new AstVar(new FileLine("uhdm"),
-                                 parameter_type,
-                                 objectName,
-                                 VFlagChildDType(),
-                                 dtype);
-          parameter->valuep(parameter_value);
-          return parameter;
+            parameter = new AstVar(new FileLine("uhdm"), parameter_type, objectName,
+                                   VFlagChildDType(), dtype);
+            parameter->valuep(parameter_value);
+            return parameter;
         }
-      }
-      case vpiInterface: {
+    }
+    case vpiInterface: {
         // Interface definition is represented by a module node
         AstIface* elaboratedInterface = new AstIface(new FileLine("uhdm"), objectName);
         bool hasModports = false;
-        visit_one_to_many({
-            vpiPort,
-            vpiParameter,
-            vpiInterfaceTfDecl,
-            vpiModPath,
-            vpiContAssign,
-            vpiInterface,
-            vpiInterfaceArray,
-            vpiProcess,
-            vpiGenScopeArray,
+        visit_one_to_many(
+            {
+                vpiPort,
+                vpiParameter,
+                vpiInterfaceTfDecl,
+                vpiModPath,
+                vpiContAssign,
+                vpiInterface,
+                vpiInterfaceArray,
+                vpiProcess,
+                vpiGenScopeArray,
 
-            // from vpiInstance
-            vpiProgram,
-            vpiProgramArray,
-            vpiTaskFunc,
-            vpiArrayNet,
-            vpiSpecParam,
-            vpiAssertion,
-            vpiNet,
+                // from vpiInstance
+                vpiProgram,
+                vpiProgramArray,
+                vpiTaskFunc,
+                vpiArrayNet,
+                vpiSpecParam,
+                vpiAssertion,
+                vpiNet,
             },
-            obj_h,
-            visited,
-            top_nodes,
-            [&](AstNode* port){
-          if(port) {
-            elaboratedInterface->addStmtp(port);
-          }
-        });
-        visit_one_to_many({vpiModport}, obj_h, visited, top_nodes, [&](AstNode* port){
-          if(port) {
-            hasModports = true;
-            elaboratedInterface->addStmtp(port);
-          }
+            obj_h, visited, top_nodes, [&](AstNode* port) {
+                if (port) { elaboratedInterface->addStmtp(port); }
+            });
+        visit_one_to_many({vpiModport}, obj_h, visited, top_nodes, [&](AstNode* port) {
+            if (port) {
+                hasModports = true;
+                elaboratedInterface->addStmtp(port);
+            }
         });
         if (hasModports) {
-          // Only then create the nets, as they won't be connected otherwise
-          visit_one_to_many({vpiNet}, obj_h, visited, top_nodes, [&](AstNode* port){
-            if(port) {
-              elaboratedInterface->addStmtp(port);
-            }
-          });
+            // Only then create the nets, as they won't be connected otherwise
+            visit_one_to_many({vpiNet}, obj_h, visited, top_nodes, [&](AstNode* port) {
+                if (port) { elaboratedInterface->addStmtp(port); }
+            });
         }
 
         elaboratedInterface->name(objectName);
         std::string modType = vpi_get_str(vpiDefName, obj_h);
         sanitize_str(modType);
         if (objectName != modType) {
-          AstPin *modPins = nullptr;
-          vpiHandle itr = vpi_iterate(vpiPort, obj_h);
-          int np = 0;
-          while (vpiHandle vpi_child_obj = vpi_scan(itr) ) {
-            vpiHandle highConn = vpi_handle(vpiHighConn, vpi_child_obj);
-            if (highConn) {
-              std::string portName = vpi_get_str(vpiName, vpi_child_obj);
-              sanitize_str(portName);
-              AstParseRef *ref = reinterpret_cast<AstParseRef *>(visit_object(highConn, visited, top_nodes));
-              AstPin *pin = new AstPin(new FileLine("uhdm"), ++np, portName, ref);
-              if (!modPins)
-                  modPins = pin;
-              else
-                  modPins->addNextNull(pin);
+            AstPin* modPins = nullptr;
+            vpiHandle itr = vpi_iterate(vpiPort, obj_h);
+            int np = 0;
+            while (vpiHandle vpi_child_obj = vpi_scan(itr)) {
+                vpiHandle highConn = vpi_handle(vpiHighConn, vpi_child_obj);
+                if (highConn) {
+                    std::string portName = vpi_get_str(vpiName, vpi_child_obj);
+                    sanitize_str(portName);
+                    AstParseRef* ref = reinterpret_cast<AstParseRef*>(
+                        visit_object(highConn, visited, top_nodes));
+                    AstPin* pin = new AstPin(new FileLine("uhdm"), ++np, portName, ref);
+                    if (!modPins)
+                        modPins = pin;
+                    else
+                        modPins->addNextNull(pin);
+                }
+
+                vpi_free_object(vpi_child_obj);
             }
+            vpi_free_object(itr);
 
-            vpi_free_object(vpi_child_obj);
-          }
-          vpi_free_object(itr);
-
-          AstCell *cell = new AstCell(new FileLine("uhdm"), new FileLine("uhdm"),
-              objectName, modType, modPins, nullptr, nullptr);
-          return cell;
+            AstCell* cell = new AstCell(new FileLine("uhdm"), new FileLine("uhdm"), objectName,
+                                        modType, modPins, nullptr, nullptr);
+            return cell;
         } else {
-          // is top level
-          return elaboratedInterface;
+            // is top level
+            return elaboratedInterface;
         }
         break;
-      }
-      case vpiModport: {
+    }
+    case vpiModport: {
         AstNode* modport_vars = nullptr;
 
         // We construct a reference here, the net is created in the interface
         // No full visit, just grab name and direction
         auto io_itr = vpi_iterate(vpiIODecl, obj_h);
-        while (vpiHandle io_h = vpi_scan(io_itr) ) {
-          std::string io_name;
-          if (auto s = vpi_get_str(vpiName, io_h)) {
-            io_name = s;
-            sanitize_str(io_name);
-          }
-          VDirection dir;
-          if (const int n = vpi_get(vpiDirection, io_h)) {
-            if (n == vpiInput) {
-              dir = VDirection::INPUT;
-            } else if (n == vpiOutput) {
-              dir = VDirection::OUTPUT;
-            } else if (n == vpiInout) {
-              dir = VDirection::INOUT;
+        while (vpiHandle io_h = vpi_scan(io_itr)) {
+            std::string io_name;
+            if (auto s = vpi_get_str(vpiName, io_h)) {
+                io_name = s;
+                sanitize_str(io_name);
             }
-          }
-          auto* io_node = new AstModportVarRef(new FileLine("uhdm"), io_name, dir);
-          if (modport_vars)
-            modport_vars->addNextNull(io_node);
-          else
-            modport_vars = io_node;
-          vpi_free_object(io_h);
+            VDirection dir;
+            if (const int n = vpi_get(vpiDirection, io_h)) {
+                if (n == vpiInput) {
+                    dir = VDirection::INPUT;
+                } else if (n == vpiOutput) {
+                    dir = VDirection::OUTPUT;
+                } else if (n == vpiInout) {
+                    dir = VDirection::INOUT;
+                }
+            }
+            auto* io_node = new AstModportVarRef(new FileLine("uhdm"), io_name, dir);
+            if (modport_vars)
+                modport_vars->addNextNull(io_node);
+            else
+                modport_vars = io_node;
+            vpi_free_object(io_h);
         }
         vpi_free_object(io_itr);
 
         return new AstModport(new FileLine("uhdm"), objectName, modport_vars);
-      }
-      case vpiIODecl: {
+    }
+    case vpiIODecl: {
         // For function arguments, the actual type
         // is inside vpiExpr
         AstNode* expr = nullptr;
-        visit_one_to_one({vpiExpr}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (item) {
-              expr = item;
-            }
-          });
+        visit_one_to_one({vpiExpr}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item) { expr = item; }
+        });
         if (expr != nullptr) {
-          // Override name with IO name
-          expr->name(objectName);
-          return expr;
-        } // else handle as normal IODecl
+            // Override name with IO name
+            expr->name(objectName);
+            return expr;
+        }  // else handle as normal IODecl
 
         VDirection dir;
         if (const int n = vpi_get(vpiDirection, obj_h)) {
-          if (n == vpiInput) {
-            dir = VDirection::INPUT;
-          } else if (n == vpiOutput) {
-            dir = VDirection::OUTPUT;
-          } else if (n == vpiInout) {
-            dir = VDirection::INOUT;
-          }
+            if (n == vpiInput) {
+                dir = VDirection::INPUT;
+            } else if (n == vpiOutput) {
+                dir = VDirection::OUTPUT;
+            } else if (n == vpiInout) {
+                dir = VDirection::INOUT;
+            }
         }
 
         AstRange* var_range = nullptr;
-        visit_one_to_many({vpiRange}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (item) {
-                var_range = reinterpret_cast<AstRange*>(item);
-            }
-          });
-        auto* dtype = new AstBasicDType(new FileLine("uhdm"),
-                              AstBasicDTypeKwd::LOGIC);
+        visit_one_to_many({vpiRange}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item) { var_range = reinterpret_cast<AstRange*>(item); }
+        });
+        auto* dtype = new AstBasicDType(new FileLine("uhdm"), AstBasicDTypeKwd::LOGIC);
         dtype->rangep(var_range);
-        auto* var = new AstVar(new FileLine("uhdm"),
-                         AstVarType::PORT,
-                         objectName,
-                         VFlagChildDType(),
-                         dtype);
+        auto* var = new AstVar(new FileLine("uhdm"), AstVarType::PORT, objectName,
+                               VFlagChildDType(), dtype);
         var->declDirection(dir);
         var->direction(dir);
         return var;
-      }
-      case vpiAlways: {
+    }
+    case vpiAlways: {
         VAlwaysKwd alwaysType;
         AstSenTree* senTree = nullptr;
         AstNode* body = nullptr;
 
         // Which always type is it?
-        switch(vpi_get(vpiAlwaysType, obj_h)) {
-            case vpiAlways: {
-              alwaysType = VAlwaysKwd::ALWAYS;
-              break;
-            }
-            case vpiAlwaysFF: {
-              alwaysType = VAlwaysKwd::ALWAYS_FF;
-              break;
-            }
-            case vpiAlwaysLatch: {
-              alwaysType = VAlwaysKwd::ALWAYS_LATCH;
-              break;
-            }
-            case vpiAlwaysComb: {
-              alwaysType = VAlwaysKwd::ALWAYS_COMB;
-              break;
-            }
-            default: {
-              v3error("Unhandled always type");
-              break;
-            }
+        switch (vpi_get(vpiAlwaysType, obj_h)) {
+        case vpiAlways: {
+            alwaysType = VAlwaysKwd::ALWAYS;
+            break;
+        }
+        case vpiAlwaysFF: {
+            alwaysType = VAlwaysKwd::ALWAYS_FF;
+            break;
+        }
+        case vpiAlwaysLatch: {
+            alwaysType = VAlwaysKwd::ALWAYS_LATCH;
+            break;
+        }
+        case vpiAlwaysComb: {
+            alwaysType = VAlwaysKwd::ALWAYS_COMB;
+            break;
+        }
+        default: {
+            v3error("Unhandled always type");
+            break;
+        }
         }
 
-        if (alwaysType != VAlwaysKwd::ALWAYS_COMB
-            && alwaysType != VAlwaysKwd::ALWAYS_LATCH) {
-          // Handled in vpiEventControl
-          AstNode* always;
+        if (alwaysType != VAlwaysKwd::ALWAYS_COMB && alwaysType != VAlwaysKwd::ALWAYS_LATCH) {
+            // Handled in vpiEventControl
+            AstNode* always;
 
-          visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              always = node;
-            });
-          return always;
+            visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
+                             [&](AstNode* node) { always = node; });
+            return always;
         } else {
-          // Body of statements
-          visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              body = node;
-            });
+            // Body of statements
+            visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
+                             [&](AstNode* node) { body = node; });
         }
 
         return new AstAlways(new FileLine("uhdm"), alwaysType, senTree, body);
-      }
-      case vpiEventControl: {
+    }
+    case vpiEventControl: {
         AstSenItem* senItemRoot;
         AstNode* body = nullptr;
         AstSenTree* senTree = nullptr;
-        visit_one_to_one({vpiCondition}, obj_h, visited, top_nodes,
-          [&](AstNode* node){
+        visit_one_to_one({vpiCondition}, obj_h, visited, top_nodes, [&](AstNode* node) {
             if (node->type() == AstType::en::atSenItem) {
-              senItemRoot = reinterpret_cast<AstSenItem*>(node);
+                senItemRoot = reinterpret_cast<AstSenItem*>(node);
+            } else {  // wrap this in a AstSenItem
+                senItemRoot = new AstSenItem(new FileLine("uhdm"), VEdgeType::ET_ANYEDGE, node);
             }
-            else { // wrap this in a AstSenItem
-              senItemRoot = new AstSenItem(new FileLine("uhdm"),
-                                           VEdgeType::ET_ANYEDGE,
-                                           node);
-            }
-          });
+        });
         senTree = new AstSenTree(new FileLine("uhdm"), senItemRoot);
         // Body of statements
         visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
-          [&](AstNode* node){
-            body = node;
-          });
+                         [&](AstNode* node) { body = node; });
         auto* tctrl = new AstTimingControl(new FileLine("uhdm"), senTree, body);
         return new AstAlways(new FileLine("uhdm"), VAlwaysKwd::ALWAYS_FF, nullptr, tctrl);
-      }
-      case vpiInitial: {
+    }
+    case vpiInitial: {
         AstNode* body = nullptr;
         visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
-          [&](AstNode* node){
-            body = node;
-          });
+                         [&](AstNode* node) { body = node; });
         return new AstInitial(new FileLine("uhdm"), body);
-      }
-      case vpiFinal: {
+    }
+    case vpiFinal: {
         AstNode* body = nullptr;
         visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
-          [&](AstNode* node){
-            body = node;
-          });
+                         [&](AstNode* node) { body = node; });
         return new AstFinal(new FileLine("uhdm"), body);
-      }
-      case vpiNamedBegin:
-      case vpiBegin: {
+    }
+    case vpiNamedBegin:
+    case vpiBegin: {
         AstNode* body = nullptr;
-        visit_one_to_many({
-            vpiTypedef,
-            vpiStmt,
-            vpiPropertyDecl,
-            vpiSequenceDecl,
-            vpiConcurrentAssertions,
-            vpiNamedEvent,
-            vpiNamedEventArray,
-            vpiVariables,
-            vpiVirtualInterfaceVar,
-            vpiReg,
-            vpiRegArray,
-            vpiMemory,
-            vpiParameter,
-            vpiParamAssign,
-            vpiInternalScope,
-            vpiImport,
-            vpiAttribute,
-            vpiNet,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* node){
-            if (body == nullptr) {
-              body = node;
-            } else {
-              body->addNextNull(node);
-            }
-          });
+        visit_one_to_many(
+            {
+                vpiTypedef,
+                vpiStmt,
+                vpiPropertyDecl,
+                vpiSequenceDecl,
+                vpiConcurrentAssertions,
+                vpiNamedEvent,
+                vpiNamedEventArray,
+                vpiVariables,
+                vpiVirtualInterfaceVar,
+                vpiReg,
+                vpiRegArray,
+                vpiMemory,
+                vpiParameter,
+                vpiParamAssign,
+                vpiInternalScope,
+                vpiImport,
+                vpiAttribute,
+                vpiNet,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (body == nullptr) {
+                    body = node;
+                } else {
+                    body->addNextNull(node);
+                }
+            });
         if (objectType == vpiBegin) {
-          objectName = "";  // avoid storing parent name
+            objectName = "";  // avoid storing parent name
         }
         return new AstBegin(new FileLine("uhdm"), "", body);
-      }
-      case vpiIf:
-      case vpiIfElse: {
+    }
+    case vpiIf:
+    case vpiIfElse: {
         AstNode* condition = nullptr;
         AstNode* statement = nullptr;
         AstNode* elseStatement = nullptr;
 
         visit_one_to_one({vpiCondition}, obj_h, visited, top_nodes,
-          [&](AstNode* node){
-            condition = node;
-          });
+                         [&](AstNode* node) { condition = node; });
         visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
-          [&](AstNode* node){
-            statement = node;
-          });
+                         [&](AstNode* node) { statement = node; });
         if (objectType == vpiIfElse) {
-          visit_one_to_one({vpiElseStmt}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              elseStatement = node;
-            });
+            visit_one_to_one({vpiElseStmt}, obj_h, visited, top_nodes,
+                             [&](AstNode* node) { elseStatement = node; });
         }
         return new AstIf(new FileLine("uhdm"), condition, statement, elseStatement);
-      }
-      case vpiCase: {
+    }
+    case vpiCase: {
         VCaseType case_type;
         switch (vpi_get(vpiCaseType, obj_h)) {
-          case vpiCaseExact: {
+        case vpiCaseExact: {
             case_type = VCaseType::en::CT_CASE;
             break;
-          }
-          case vpiCaseX: {
+        }
+        case vpiCaseX: {
             case_type = VCaseType::en::CT_CASEX;
             break;
-          }
-          case vpiCaseZ: {
+        }
+        case vpiCaseZ: {
             case_type = VCaseType::en::CT_CASEZ;
             break;
-          }
-          default: {
+        }
+        default: {
             // Should never be reached
             break;
-          }
+        }
         }
         AstNode* conditionNode = nullptr;
         visit_one_to_one({vpiCondition}, obj_h, visited, top_nodes,
-          [&](AstNode* node){
-            conditionNode = node;
-          });
+                         [&](AstNode* node) { conditionNode = node; });
         AstNode* itemNodes = nullptr;
-        visit_one_to_many({vpiCaseItem}, obj_h, visited, top_nodes,
-            [&](AstNode* item){
-              if (item) {
+        visit_one_to_many({vpiCaseItem}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item) {
                 if (itemNodes == nullptr) {
-                  itemNodes = item;
+                    itemNodes = item;
                 } else {
-                  itemNodes->addNextNull(item);
+                    itemNodes->addNextNull(item);
                 }
-              }
-            });
+            }
+        });
         return new AstCase(new FileLine("uhdm"), case_type, conditionNode, itemNodes);
-      }
-      case vpiCaseItem: {
+    }
+    case vpiCaseItem: {
         AstNode* expressionNode = nullptr;
-        visit_one_to_many({vpiExpr}, obj_h, visited, top_nodes,
-            [&](AstNode* item){
-              if (item) {
+        visit_one_to_many({vpiExpr}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item) {
                 if (expressionNode == nullptr) {
-                  expressionNode = item;
+                    expressionNode = item;
                 } else {
-                  expressionNode->addNextNull(item);
+                    expressionNode->addNextNull(item);
                 }
-              }
-            });
+            }
+        });
         AstNode* bodyNode = nullptr;
         visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
-          [&](AstNode* node){
-            bodyNode = node;
-          });
+                         [&](AstNode* node) { bodyNode = node; });
         return new AstCaseItem(new FileLine("uhdm"), expressionNode, bodyNode);
-      }
-      case vpiOperation: {
+    }
+    case vpiOperation: {
         AstNode* rhs = nullptr;
         AstNode* lhs = nullptr;
         auto operation = vpi_get(vpiOpType, obj_h);
         switch (operation) {
-          case vpiBitNegOp: {
+        case vpiBitNegOp: {
             visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              rhs = node;
-            });
+                              [&](AstNode* node) { rhs = node; });
             return new AstNot(new FileLine("uhdm"), rhs);
-          }
-          case vpiNotOp: {
+        }
+        case vpiNotOp: {
             visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              lhs = node;
-            });
+                              [&](AstNode* node) { lhs = node; });
             return new AstLogNot(new FileLine("uhdm"), lhs);
-          }
-          case vpiBitAndOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiBitAndOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (lhs == nullptr) {
-                  lhs = node;
+                    lhs = node;
                 } else {
-                  rhs = node;
+                    rhs = node;
                 }
-              });
+            });
             return new AstAnd(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiListOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiListOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (rhs == nullptr) {
-                  rhs = node;
+                    rhs = node;
                 } else {
-                  rhs->addNextNull(node);
+                    rhs->addNextNull(node);
                 }
-              });
+            });
             return rhs;
-          }
-          case vpiBitOrOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiBitOrOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (lhs == nullptr) {
-                  lhs = node;
+                    lhs = node;
                 } else {
-                  rhs = node;
+                    rhs = node;
                 }
-              });
+            });
             return new AstOr(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiBitXorOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiBitXorOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (rhs == nullptr) {
-                  rhs = node;
+                    rhs = node;
                 } else {
-                  lhs = node;
+                    lhs = node;
                 }
-              });
+            });
             return new AstXor(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiBitXnorOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiBitXnorOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (rhs == nullptr) {
-                  rhs = node;
+                    rhs = node;
                 } else {
-                  lhs = node;
+                    lhs = node;
                 }
-              });
+            });
             return new AstXnor(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiPostIncOp:
-          case vpiPostDecOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (rhs == nullptr) {
-                  rhs = node;
-                }
-              });
+        }
+        case vpiPostIncOp:
+        case vpiPostDecOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (rhs == nullptr) { rhs = node; }
+            });
             auto* one = new AstConst(new FileLine("uhdm"), 1);
             AstNode* op = nullptr;
             if (operation == vpiPostIncOp) {
-              op = new AstAdd(new FileLine("uhdm"), rhs, one);
+                op = new AstAdd(new FileLine("uhdm"), rhs, one);
             } else if (operation == vpiPostDecOp) {
-              op = new AstSub(new FileLine("uhdm"), rhs, one);
+                op = new AstSub(new FileLine("uhdm"), rhs, one);
             }
-            auto* var = new AstParseRef(new FileLine("uhdm"),
-                                               VParseRefExp::en::PX_TEXT,
-                                               rhs->name(),
-                                               nullptr,
-                                               nullptr);
+            auto* var = new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT,
+                                        rhs->name(), nullptr, nullptr);
             return new AstAssign(new FileLine("uhdm"), var, op);
-          }
-          case vpiAssignmentOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiAssignmentOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (lhs == nullptr) {
-                  lhs = node;
+                    lhs = node;
                 } else {
-                  rhs = node;
+                    rhs = node;
                 }
-              });
+            });
             return new AstAssign(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiUnaryAndOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (rhs == nullptr) {
-                  rhs = node;
-                }
-              });
+        }
+        case vpiUnaryAndOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (rhs == nullptr) { rhs = node; }
+            });
             return new AstRedAnd(new FileLine("uhdm"), rhs);
-          }
-          case vpiUnaryNandOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (rhs == nullptr) {
-                  rhs = node;
-                }
-              });
+        }
+        case vpiUnaryNandOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (rhs == nullptr) { rhs = node; }
+            });
             auto* op = new AstRedAnd(new FileLine("uhdm"), rhs);
             return new AstNot(new FileLine("uhdm"), op);
-          }
-          case vpiUnaryNorOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (rhs == nullptr) {
-                  rhs = node;
-                }
-              });
+        }
+        case vpiUnaryNorOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (rhs == nullptr) { rhs = node; }
+            });
             auto* op = new AstRedOr(new FileLine("uhdm"), rhs);
             return new AstNot(new FileLine("uhdm"), op);
-          }
-          case vpiUnaryOrOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (rhs == nullptr) {
-                  rhs = node;
-                }
-              });
+        }
+        case vpiUnaryOrOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (rhs == nullptr) { rhs = node; }
+            });
             return new AstRedOr(new FileLine("uhdm"), rhs);
-          }
-          case vpiUnaryXorOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (rhs == nullptr) {
-                  rhs = node;
-                }
-              });
+        }
+        case vpiUnaryXorOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (rhs == nullptr) { rhs = node; }
+            });
             return new AstRedXor(new FileLine("uhdm"), rhs);
-          }
-          case vpiUnaryXNorOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (rhs == nullptr) {
-                  rhs = node;
-                }
-              });
+        }
+        case vpiUnaryXNorOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (rhs == nullptr) { rhs = node; }
+            });
             return new AstRedXnor(new FileLine("uhdm"), rhs);
-          }
-          case vpiEventOrOp: {
+        }
+        case vpiEventOrOp: {
             // Do not create a separate node
             // Chain operand nodes instead
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (node) {
-                  if (node->type() == AstType::en::atSenItem) {
-                    // This is a Posedge/Negedge operation, keep this node
-                    if (rhs == nullptr) {
-                      rhs = node;
+                    if (node->type() == AstType::en::atSenItem) {
+                        // This is a Posedge/Negedge operation, keep this node
+                        if (rhs == nullptr) {
+                            rhs = node;
+                        } else {
+                            rhs->addNextNull(node);
+                        }
                     } else {
-                    rhs->addNextNull(node);
+                        // Edge not specified -> use ANY
+                        auto* wrapper
+                            = new AstSenItem(new FileLine("uhdm"), VEdgeType::ET_ANYEDGE, node);
+                        if (rhs == nullptr) {
+                            rhs = wrapper;
+                        } else {
+                            rhs->addNextNull(wrapper);
+                        }
                     }
-                  } else {
-                    // Edge not specified -> use ANY
-                    auto* wrapper = new AstSenItem(new FileLine("uhdm"),
-                                                   VEdgeType::ET_ANYEDGE,
-                                                   node);
-                    if (rhs == nullptr) {
-                        rhs = wrapper;
-                    } else {
-                      rhs->addNextNull(wrapper);
-                    }
-                  }
                 }
-              });
+            });
             return rhs;
-          }
-          case vpiLogAndOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiLogAndOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstLogAnd(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiLogOrOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstLogOr(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiPosedgeOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              rhs = node;
-            });
-            return new AstSenItem(new FileLine("uhdm"),
-                                  VEdgeType::ET_POSEDGE,
-                                  rhs);
-          }
-          case vpiNegedgeOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              rhs = node;
-            });
-            return new AstSenItem(new FileLine("uhdm"),
-                                  VEdgeType::ET_NEGEDGE,
-                                  rhs);
-          }
-          case vpiEqOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstEq(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiCaseEqOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstEqCase(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiNeqOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstNeq(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiCaseNeqOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstNeqCase(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiGtOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstGt(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiGeOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstGte(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiLtOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstLt(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiLeOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstLte(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiPlusOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstAdd(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiSubOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstSub(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiMinusOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                }
-              });
-            return new AstNegate(new FileLine("uhdm"), lhs);
-          }
-          case vpiAddOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstAdd(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiMultOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstMul(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiDivOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstDiv(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiModOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstModDiv(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiConditionOp: {
-            AstNode* condition = nullptr;
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (condition == nullptr) {
-                  condition = node;
-                  } else if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstCond(new FileLine("uhdm"), condition, lhs, rhs);
-          }
-          case vpiConcatOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if(node != nullptr) {
-                  if (lhs == nullptr) {
                     lhs = node;
-                  } else if (rhs == nullptr) {
+                } else {
                     rhs = node;
-                  } else {
-                    // Add one more level
-                    lhs = new AstConcat(new FileLine("uhdm"), lhs, rhs);
-                    rhs = node;
-                  }
                 }
-              });
+            });
+            return new AstLogAnd(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiLogOrOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstLogOr(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiPosedgeOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
+                              [&](AstNode* node) { rhs = node; });
+            return new AstSenItem(new FileLine("uhdm"), VEdgeType::ET_POSEDGE, rhs);
+        }
+        case vpiNegedgeOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
+                              [&](AstNode* node) { rhs = node; });
+            return new AstSenItem(new FileLine("uhdm"), VEdgeType::ET_NEGEDGE, rhs);
+        }
+        case vpiEqOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstEq(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiCaseEqOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstEqCase(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiNeqOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstNeq(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiCaseNeqOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstNeqCase(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiGtOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstGt(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiGeOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstGte(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiLtOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstLt(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiLeOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstLte(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiPlusOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstAdd(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiSubOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstSub(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiMinusOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) { lhs = node; }
+            });
+            return new AstNegate(new FileLine("uhdm"), lhs);
+        }
+        case vpiAddOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstAdd(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiMultOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstMul(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiDivOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstDiv(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiModOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstModDiv(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiConditionOp: {
+            AstNode* condition = nullptr;
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (condition == nullptr) {
+                    condition = node;
+                } else if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstCond(new FileLine("uhdm"), condition, lhs, rhs);
+        }
+        case vpiConcatOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (node != nullptr) {
+                    if (lhs == nullptr) {
+                        lhs = node;
+                    } else if (rhs == nullptr) {
+                        rhs = node;
+                    } else {
+                        // Add one more level
+                        lhs = new AstConcat(new FileLine("uhdm"), lhs, rhs);
+                        rhs = node;
+                    }
+                }
+            });
             // Wrap in a Replicate node
             if (rhs != nullptr) {
-              lhs = new AstConcat(new FileLine("uhdm"), lhs, rhs);
-              rhs = new AstConst(new FileLine("uhdm"), 1);
+                lhs = new AstConcat(new FileLine("uhdm"), lhs, rhs);
+                rhs = new AstConst(new FileLine("uhdm"), 1);
             } else {
-              rhs = new AstConst(new FileLine("uhdm"), 1);
+                rhs = new AstConst(new FileLine("uhdm"), 1);
             }
             return new AstReplicate(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiMultiConcatOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiMultiConcatOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (lhs == nullptr) {
-                  lhs = node;
+                    lhs = node;
                 } else if (rhs == nullptr) {
-                  rhs = node;
+                    rhs = node;
                 }
-              });
+            });
             // Sides in AST are switched: first rhs (value), then lhs (count)
             return new AstReplicate(new FileLine("uhdm"), rhs, lhs);
-          }
-          case vpiArithLShiftOp:  // This behaves the same as normal shift
-          case vpiLShiftOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiArithLShiftOp:  // This behaves the same as normal shift
+        case vpiLShiftOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstShiftL(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiRShiftOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstShiftR(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiArithRShiftOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (lhs == nullptr) {
-                  lhs = node;
-                } else {
-                  rhs = node;
-                }
-              });
-            return new AstShiftRS(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiInsideOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
-                if (node != nullptr) {
-                  if (lhs == nullptr) {
                     lhs = node;
-                  } else if (rhs == nullptr) {
+                } else {
                     rhs = node;
-                  } else {
-                    rhs->addNextNull(node);
-                  }
                 }
-              });
-            return new AstInside(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiCastOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+            });
+            return new AstShiftL(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiRShiftOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (lhs == nullptr) {
-                  lhs = node;
+                    lhs = node;
+                } else {
+                    rhs = node;
                 }
-              });
+            });
+            return new AstShiftR(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiArithRShiftOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) {
+                    lhs = node;
+                } else {
+                    rhs = node;
+                }
+            });
+            return new AstShiftRS(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiInsideOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (node != nullptr) {
+                    if (lhs == nullptr) {
+                        lhs = node;
+                    } else if (rhs == nullptr) {
+                        rhs = node;
+                    } else {
+                        rhs->addNextNull(node);
+                    }
+                }
+            });
+            return new AstInside(new FileLine("uhdm"), lhs, rhs);
+        }
+        case vpiCastOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                if (lhs == nullptr) { lhs = node; }
+            });
             auto typespec_h = vpi_handle(vpiTypespec, obj_h);
             std::set<int> typespec_types = {
-                vpiClassTypespec,
-                vpiEnumTypespec,
-                vpiStructTypespec,
-                vpiUnionTypespec,
-                vpiVoidTypespec,
-                };
-            if(typespec_types.count(vpi_get(vpiType, typespec_h)) != 0) {
-              // Custom type, create reference only
-              std::string name;
-              if (auto s = vpi_get_str(vpiName, typespec_h)) {
-                name = s;
-                sanitize_str(name);
-              } else {
-                v3error("Encountered custom, but unnamed typespec");
-              }
-              return new AstCast(new FileLine("uhdm"),
-                                 lhs,
-                                 new AstRefDType(new FileLine("uhdm"), name));
+                vpiClassTypespec, vpiEnumTypespec, vpiStructTypespec,
+                vpiUnionTypespec, vpiVoidTypespec,
+            };
+            if (typespec_types.count(vpi_get(vpiType, typespec_h)) != 0) {
+                // Custom type, create reference only
+                std::string name;
+                if (auto s = vpi_get_str(vpiName, typespec_h)) {
+                    name = s;
+                    sanitize_str(name);
+                } else {
+                    v3error("Encountered custom, but unnamed typespec");
+                }
+                return new AstCast(new FileLine("uhdm"), lhs,
+                                   new AstRefDType(new FileLine("uhdm"), name));
             } else {
-              visit_one_to_one({vpiTypespec}, obj_h, visited, top_nodes,
-                [&](AstNode* node){
-                  if (rhs == nullptr) {
-                    rhs = node;
-                  }
+                visit_one_to_one({vpiTypespec}, obj_h, visited, top_nodes, [&](AstNode* node) {
+                    if (rhs == nullptr) { rhs = node; }
                 });
             }
             return new AstCastParse(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiStreamRLOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiStreamRLOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (lhs == nullptr) {
-                  lhs = node;
-                }else if (rhs == nullptr) {
-                  rhs = node;
+                    lhs = node;
+                } else if (rhs == nullptr) {
+                    rhs = node;
                 }
-              });
+            });
 
             // Verilog {rhs{lhs}} - Note rhs() is the slice size, not the lhs()
             // IEEE 11.4.14.2: If a slice_size is not specified, the default is 1.
             if (rhs == nullptr) {
-              return new AstStreamL(new FileLine("uhdm"),
-                                    lhs,
-                                    new AstConst(new FileLine("uhdm"), 1));
+                return new AstStreamL(new FileLine("uhdm"), lhs,
+                                      new AstConst(new FileLine("uhdm"), 1));
             } else {
-              return new AstStreamL(new FileLine("uhdm"), lhs, rhs);
+                return new AstStreamL(new FileLine("uhdm"), lhs, rhs);
             }
-          }
-          case vpiStreamLROp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiStreamLROp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (lhs == nullptr) {
-                  lhs = node;
-                }else if (rhs == nullptr) {
-                  rhs = node;
+                    lhs = node;
+                } else if (rhs == nullptr) {
+                    rhs = node;
                 }
-              });
+            });
             // See comments above - default rhs is 1
             if (rhs == nullptr) {
-              return new AstStreamR(new FileLine("uhdm"),
-                                    lhs,
-                                    new AstConst(new FileLine("uhdm"), 1));
+                return new AstStreamR(new FileLine("uhdm"), lhs,
+                                      new AstConst(new FileLine("uhdm"), 1));
             } else {
-              return new AstStreamR(new FileLine("uhdm"), lhs, rhs);
+                return new AstStreamR(new FileLine("uhdm"), lhs, rhs);
             }
-          }
-          case vpiPowerOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiPowerOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 if (lhs == nullptr) {
-                  lhs = node;
+                    lhs = node;
                 } else {
-                  rhs = node;
+                    rhs = node;
                 }
-              });
+            });
             return new AstPow(new FileLine("uhdm"), lhs, rhs);
-          }
-          case vpiAssignmentPatternOp: {
-            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes,
-              [&](AstNode* node){
+        }
+        case vpiAssignmentPatternOp: {
+            visit_one_to_many({vpiOperand}, obj_h, visited, top_nodes, [&](AstNode* node) {
                 // Wrap only if this is a positional pattern
                 // Tagged patterns will return member nodes
                 if (node && !VN_IS(node, PatMember)) {
-                  node = new AstPatMember(new FileLine("uhdm"),
-                      node,
-                      nullptr,
-                      nullptr);
+                    node = new AstPatMember(new FileLine("uhdm"), node, nullptr, nullptr);
                 }
                 if (lhs == nullptr) {
-                  lhs = node;
+                    lhs = node;
                 } else {
-                  lhs->addNextNull(node);
+                    lhs->addNextNull(node);
                 }
-              });
+            });
             return new AstPattern(new FileLine("uhdm"), lhs);
-          }
-          default: {
+        }
+        default: {
             v3error("\t! Encountered unhandled operation: " << operation);
             break;
-          }
+        }
         }
         return nullptr;
-      }
-      case vpiTaggedPattern: {
+    }
+    case vpiTaggedPattern: {
         AstNode* typespec = nullptr;
         AstNode* pattern = nullptr;
         auto typespec_h = vpi_handle(vpiTypespec, obj_h);
         std::string pattern_name;
-        if (auto s = vpi_get_str(vpiName, typespec_h)) {
-          pattern_name = s;
-        }
+        if (auto s = vpi_get_str(vpiName, typespec_h)) { pattern_name = s; }
         sanitize_str(pattern_name);
         typespec = new AstText(new FileLine("uhdm"), pattern_name);
 
         visit_one_to_one({vpiPattern}, obj_h, visited, top_nodes,
-          [&](AstNode* node){
-            pattern = node;
-          });
+                         [&](AstNode* node) { pattern = node; });
         if (pattern_name == "default") {
-          auto* patm = new AstPatMember(new FileLine("uhdm"),
-                                        pattern,
-                                        nullptr,
-                                        nullptr);
-          patm->isDefault(true);
-          return patm;
+            auto* patm = new AstPatMember(new FileLine("uhdm"), pattern, nullptr, nullptr);
+            patm->isDefault(true);
+            return patm;
         } else {
-          return new AstPatMember(new FileLine("uhdm"),
-                                  pattern,
-                                  typespec,
-                                  nullptr);
+            return new AstPatMember(new FileLine("uhdm"), pattern, typespec, nullptr);
         }
-      }
-      case vpiEnumConst:
-      case vpiConstant: {
+    }
+    case vpiEnumConst:
+    case vpiConstant: {
         return get_value_as_node(obj_h);
-      }
-      case vpiBitSelect: {
-        auto* fromp = new AstParseRef(new FileLine("uhdm"),
-                                               VParseRefExp::en::PX_TEXT,
-                                               objectName,
-                                               nullptr,
-                                               nullptr);
+    }
+    case vpiBitSelect: {
+        auto* fromp = new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT, objectName,
+                                      nullptr, nullptr);
         AstNode* bitp = nullptr;
-        visit_one_to_one({vpiIndex}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (item) {
-              bitp = item;
-            }
-          });
+        visit_one_to_one({vpiIndex}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item) { bitp = item; }
+        });
         return new AstSelBit(new FileLine("uhdm"), fromp, bitp);
-      }
-      case vpiVarSelect: {
-        AstNode* fromp = new AstParseRef(new FileLine("uhdm"),
-                                               VParseRefExp::en::PX_TEXT,
-                                               objectName,
-                                               nullptr,
-                                               nullptr);
+    }
+    case vpiVarSelect: {
+        AstNode* fromp = new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT,
+                                         objectName, nullptr, nullptr);
         AstNode* bitp = nullptr;
         AstNode* select = nullptr;
-        visit_one_to_many({vpiIndex}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
+        visit_one_to_many({vpiIndex}, obj_h, visited, top_nodes, [&](AstNode* item) {
             bitp = item;
             if (item->type() == AstType::en::atSelExtract) {
-              select = new AstSelExtract(new FileLine("uhdm"),
-                  fromp,
-                  ((AstSelExtract*)item)->msbp()->cloneTree(true),
-                  ((AstSelExtract*)item)->lsbp()->cloneTree(true));
-            } else if(item->type() == AstType::en::atConst) {
-              select = new AstSelBit(new FileLine("uhdm"), fromp, bitp);
+                select = new AstSelExtract(new FileLine("uhdm"), fromp,
+                                           ((AstSelExtract*)item)->msbp()->cloneTree(true),
+                                           ((AstSelExtract*)item)->lsbp()->cloneTree(true));
+            } else if (item->type() == AstType::en::atConst) {
+                select = new AstSelBit(new FileLine("uhdm"), fromp, bitp);
             } else if (item->type() == AstType::atSelPlus) {
-              AstSelPlus* selplusp = VN_CAST(item, SelPlus);
-              select = new AstSelPlus(new FileLine("uhdm"),
-                  fromp,
-                  selplusp->bitp(),
-                  selplusp->widthp());
+                AstSelPlus* selplusp = VN_CAST(item, SelPlus);
+                select = new AstSelPlus(new FileLine("uhdm"), fromp, selplusp->bitp(),
+                                        selplusp->widthp());
             } else if (item->type() == AstType::atSelMinus) {
-              AstSelMinus* selminusp = VN_CAST(item, SelMinus);
-              select = new AstSelMinus(new FileLine("uhdm"),
-                  fromp,
-                  selminusp->bitp(),
-                  selminusp->widthp());
+                AstSelMinus* selminusp = VN_CAST(item, SelMinus);
+                select = new AstSelMinus(new FileLine("uhdm"), fromp, selminusp->bitp(),
+                                         selminusp->widthp());
 
             } else {
-              select = new AstSelBit(new FileLine("uhdm"), fromp, bitp);
+                select = new AstSelBit(new FileLine("uhdm"), fromp, bitp);
             }
             fromp = select;
-          });
+        });
         return select;
-      }
-      case vpiTask: {
+    }
+    case vpiTask: {
         AstNode* statements = nullptr;
-        visit_one_to_many({vpiIODecl}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
+        visit_one_to_many({vpiIODecl}, obj_h, visited, top_nodes, [&](AstNode* item) {
             if (item) {
-              // Overwrite direction for arguments
-              auto* io = reinterpret_cast<AstVar*>(item);
-              io->direction(VDirection::INPUT);
-              if (statements)
-                statements->addNextNull(item);
-              else
-                statements = item;
+                // Overwrite direction for arguments
+                auto* io = reinterpret_cast<AstVar*>(item);
+                io->direction(VDirection::INPUT);
+                if (statements)
+                    statements->addNextNull(item);
+                else
+                    statements = item;
             }
-          });
-        visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
+        });
+        visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes, [&](AstNode* item) {
             if (item) {
-              if (statements)
-                statements->addNextNull(item);
-              else
-                statements = item;
+                if (statements)
+                    statements->addNextNull(item);
+                else
+                    statements = item;
             }
-          });
+        });
         return new AstTask(new FileLine("uhdm"), objectName, statements);
-      }
-      case vpiTaskCall: {
+    }
+    case vpiTaskCall: {
         return new AstTaskRef(new FileLine("uhdm"), objectName, nullptr);
-      }
-      case vpiFunction: {
+    }
+    case vpiFunction: {
         AstNode* statements = nullptr;
         AstNode* function_vars = nullptr;
 
         AstRange* returnRange = nullptr;
         auto return_h = vpi_handle(vpiReturn, obj_h);
         if (return_h) {
-          AstNode* dtype = getDType(return_h, visited, top_nodes);
-          function_vars = dtype;
+            AstNode* dtype = getDType(return_h, visited, top_nodes);
+            function_vars = dtype;
         }
 
-        visit_one_to_many({vpiIODecl}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
+        visit_one_to_many({vpiIODecl}, obj_h, visited, top_nodes, [&](AstNode* item) {
             if (item) {
-              // Overwrite direction for arguments
-              auto* io = reinterpret_cast<AstVar*>(item);
-              io->direction(VDirection::INPUT);
-              if (statements)
-                statements->addNextNull(item);
-              else
-                statements = item;
+                // Overwrite direction for arguments
+                auto* io = reinterpret_cast<AstVar*>(item);
+                io->direction(VDirection::INPUT);
+                if (statements)
+                    statements->addNextNull(item);
+                else
+                    statements = item;
             }
-          });
-        visit_one_to_many({vpiVariables}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
+        });
+        visit_one_to_many({vpiVariables}, obj_h, visited, top_nodes, [&](AstNode* item) {
             if (item) {
-              if (statements)
-                statements->addNextNull(item);
-              else
-                statements = item;
+                if (statements)
+                    statements->addNextNull(item);
+                else
+                    statements = item;
             }
-          });
-        visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
+        });
+        visit_one_to_one({vpiStmt}, obj_h, visited, top_nodes, [&](AstNode* item) {
             if (item) {
-              if (statements)
-                statements->addNextNull(item);
-              else
-                statements = item;
+                if (statements)
+                    statements->addNextNull(item);
+                else
+                    statements = item;
             }
-          });
+        });
         if (return_h) {
-          return new AstFunc(new FileLine("uhdm"), objectName, statements, function_vars);
+            return new AstFunc(new FileLine("uhdm"), objectName, statements, function_vars);
         } else {
-          return new AstTask(new FileLine("uhdm"), objectName, statements);
+            return new AstTask(new FileLine("uhdm"), objectName, statements);
         }
-      }
-      case vpiReturn:
-      case vpiReturnStmt: {
+    }
+    case vpiReturn:
+    case vpiReturnStmt: {
         AstNode* condition = nullptr;
-        visit_one_to_one({vpiCondition}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (item) {
-              condition = item;
-            }
-          });
+        visit_one_to_one({vpiCondition}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item) { condition = item; }
+        });
         return new AstReturn(new FileLine("uhdm"), condition);
-        }
-      case vpiFuncCall: {
+    }
+    case vpiFuncCall: {
         AstNode* arguments = nullptr;
-        visit_one_to_many({vpiArgument}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
+        visit_one_to_many({vpiArgument}, obj_h, visited, top_nodes, [&](AstNode* item) {
             if (item) {
                 if (arguments == nullptr) {
-                  arguments = new AstArg(new FileLine("uhdm"), "", item);
+                    arguments = new AstArg(new FileLine("uhdm"), "", item);
                 } else {
-                  arguments->addNextNull(new AstArg(new FileLine("uhdm"), "", item));
+                    arguments->addNextNull(new AstArg(new FileLine("uhdm"), "", item));
                 }
             }
-          });
+        });
 
         size_t dot_pos = objectName.rfind('.');
         if (dot_pos != std::string::npos) {
-          // Split object name into prefix.method
-          //TODO: Handle >1 dot, currently all goes into prefix
-          std::string lhs = objectName.substr(0, dot_pos);
-          std::string rhs = objectName.substr(dot_pos + 1, objectName.length());
-          AstParseRef* from = new AstParseRef(new FileLine("uhdm"),
-                                              VParseRefExp::en::PX_TEXT,
-                                              lhs,
-                                              nullptr,
-                                              nullptr);
-          return new AstMethodCall(new FileLine("uhdm"), from, rhs, arguments);
+            // Split object name into prefix.method
+            // TODO: Handle >1 dot, currently all goes into prefix
+            std::string lhs = objectName.substr(0, dot_pos);
+            std::string rhs = objectName.substr(dot_pos + 1, objectName.length());
+            AstParseRef* from = new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT,
+                                                lhs, nullptr, nullptr);
+            return new AstMethodCall(new FileLine("uhdm"), from, rhs, arguments);
         }
         // Check if this is a task or function by looking for return value
         auto function_h = vpi_handle(vpiFunction, obj_h);
         auto return_h = vpi_handle(vpiReturn, function_h);
         if (return_h)
-          return new AstFuncRef(new FileLine("uhdm"), objectName, arguments);
+            return new AstFuncRef(new FileLine("uhdm"), objectName, arguments);
         else
-          return new AstTaskRef(new FileLine("uhdm"), objectName, arguments);
-      }
-      case vpiSysFuncCall: {
+            return new AstTaskRef(new FileLine("uhdm"), objectName, arguments);
+    }
+    case vpiSysFuncCall: {
         std::vector<AstNode*> arguments;
-        visit_one_to_many({vpiArgument}, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (item) {
-              arguments.push_back(item);
-            }
-          });
+        visit_one_to_many({vpiArgument}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item) { arguments.push_back(item); }
+        });
 
         if (objectName == "$signed") {
-          return new AstSigned(new FileLine("uhdm"), arguments[0]);
+            return new AstSigned(new FileLine("uhdm"), arguments[0]);
         } else if (objectName == "$unsigned") {
-          return new AstUnsigned(new FileLine("uhdm"), arguments[0]);
+            return new AstUnsigned(new FileLine("uhdm"), arguments[0]);
         } else if (objectName == "$cast") {
-          return new AstCastParse(new FileLine("uhdm"),
-                                  arguments[0],
-                                  arguments[1]);
+            return new AstCastParse(new FileLine("uhdm"), arguments[0], arguments[1]);
         } else if (objectName == "$isunknown") {
-          return new AstIsUnknown(new FileLine("uhdm"), arguments[0]);
+            return new AstIsUnknown(new FileLine("uhdm"), arguments[0]);
         } else if (objectName == "$time") {
-          return new AstTime(new FileLine("uhdm"),
-              VTimescale::TS_1PS);  //TODO: revisit once we have it in UHDM
+            return new AstTime(new FileLine("uhdm"),
+                               VTimescale::TS_1PS);  // TODO: revisit once we have it in UHDM
         } else if (objectName == "$display") {
-          AstNode* args = nullptr;
-          for (auto a : arguments) {
-            if (args == nullptr)
-              args = a;
-            else
-              args->addNextNull(a);
-          }
-          return new AstDisplay(new FileLine("uhdm"),
-                                AstDisplayType(),
-                                nullptr,
-                                args);
+            AstNode* args = nullptr;
+            for (auto a : arguments) {
+                if (args == nullptr)
+                    args = a;
+                else
+                    args->addNextNull(a);
+            }
+            return new AstDisplay(new FileLine("uhdm"), AstDisplayType(), nullptr, args);
         } else if (objectName == "$value$plusargs") {
-          node = new AstValuePlusArgs(new FileLine("uhdm"),
-                                      arguments[0],
-                                      arguments[1]);
-        } else if (objectName == "$sformat"
-                   || objectName == "$swrite") {
-          AstNode* args = nullptr;
-          // Start from second argument
-          for (auto it = ++arguments.begin(); it != arguments.end(); it++) {
-            if (args == nullptr)
-              args = *it;
-            else
-              args->addNextNull(*it);
-          }
-          return new AstSFormat(new FileLine("uhdm"),
-                                arguments[0],
-                                args);
+            node = new AstValuePlusArgs(new FileLine("uhdm"), arguments[0], arguments[1]);
+        } else if (objectName == "$sformat" || objectName == "$swrite") {
+            AstNode* args = nullptr;
+            // Start from second argument
+            for (auto it = ++arguments.begin(); it != arguments.end(); it++) {
+                if (args == nullptr)
+                    args = *it;
+                else
+                    args->addNextNull(*it);
+            }
+            return new AstSFormat(new FileLine("uhdm"), arguments[0], args);
         } else if (objectName == "$sformatf") {
-          AstNode* args = nullptr;
-          // Start from second argument
-          for (auto it = arguments.begin(); it != arguments.end(); it++) {
-            if (args == nullptr)
-              args = *it;
-            else
-              args->addNextNull(*it);
-          }
-          return new AstSFormatF(new FileLine("uhdm"),
-                                 "",
-                                 false,
-                                 args);
+            AstNode* args = nullptr;
+            // Start from second argument
+            for (auto it = arguments.begin(); it != arguments.end(); it++) {
+                if (args == nullptr)
+                    args = *it;
+                else
+                    args->addNextNull(*it);
+            }
+            return new AstSFormatF(new FileLine("uhdm"), "", false, args);
         } else if (objectName == "$finish") {
-          return new AstFinish(new FileLine("uhdm"));
+            return new AstFinish(new FileLine("uhdm"));
         } else if (objectName == "$fopen") {
-          // We need to obtain the variable in which the descriptor will be stored
-          // This usually will be LHS of an assignment fd = $fopen(...)
-          auto parent_h = vpi_handle({vpiParent}, obj_h);
-          auto lhs_h = vpi_handle({vpiLhs}, parent_h);
-          AstNode* fd = nullptr;
-          if (lhs_h) {
-            fd = visit_object(lhs_h, visited, top_nodes);
-          }
-          return new AstFOpen(new FileLine("uhdm"),
-                              fd,
-                              arguments[0],
-                              arguments[1]);
+            // We need to obtain the variable in which the descriptor will be stored
+            // This usually will be LHS of an assignment fd = $fopen(...)
+            auto parent_h = vpi_handle({vpiParent}, obj_h);
+            auto lhs_h = vpi_handle({vpiLhs}, parent_h);
+            AstNode* fd = nullptr;
+            if (lhs_h) { fd = visit_object(lhs_h, visited, top_nodes); }
+            return new AstFOpen(new FileLine("uhdm"), fd, arguments[0], arguments[1]);
         } else if (objectName == "$fclose") {
-          return new AstFClose(new FileLine("uhdm"),
-                              arguments[0]);
+            return new AstFClose(new FileLine("uhdm"), arguments[0]);
         } else if (objectName == "$fwrite") {
-          AstNode* filep = arguments[0];
-          arguments.erase(arguments.begin());
-          AstNode* args = nullptr;
-          for (auto a : arguments) {
-            if (args == nullptr)
-              args = a;
-            else
-              args->addNextNull(a);
-          }
-          return new AstDisplay(new FileLine("uhdm"),
-                                AstDisplayType(AstDisplayType::en::DT_WRITE),
-                                filep,
-                                args);
+            AstNode* filep = arguments[0];
+            arguments.erase(arguments.begin());
+            AstNode* args = nullptr;
+            for (auto a : arguments) {
+                if (args == nullptr)
+                    args = a;
+                else
+                    args->addNextNull(a);
+            }
+            return new AstDisplay(new FileLine("uhdm"),
+                                  AstDisplayType(AstDisplayType::en::DT_WRITE), filep, args);
         } else if (objectName == "$fflush") {
-          return new AstFFlush(new FileLine("uhdm"),
-                               arguments[0]);
+            return new AstFFlush(new FileLine("uhdm"), arguments[0]);
         } else if (objectName == "$clog2") {
-          return new AstCLog2(new FileLine("uhdm"),
-                              arguments[0]);
+            return new AstCLog2(new FileLine("uhdm"), arguments[0]);
         } else if (objectName == "$left") {
-          if (arguments.size() == 1)
-            arguments.push_back(nullptr);  // provide default for optional parameter
-          return new AstAttrOf(new FileLine("uhdm"),
-                               AstAttrType::DIM_LEFT,
-                               arguments[0],
-                               arguments[1]);
+            if (arguments.size() == 1)
+                arguments.push_back(nullptr);  // provide default for optional parameter
+            return new AstAttrOf(new FileLine("uhdm"), AstAttrType::DIM_LEFT, arguments[0],
+                                 arguments[1]);
         } else if (objectName == "$right") {
-          if (arguments.size() == 1)
-            arguments.push_back(nullptr);  // provide default for optional parameter
-          return new AstAttrOf(new FileLine("uhdm"),
-                               AstAttrType::DIM_RIGHT,
-                               arguments[0],
-                               arguments[1]);
+            if (arguments.size() == 1)
+                arguments.push_back(nullptr);  // provide default for optional parameter
+            return new AstAttrOf(new FileLine("uhdm"), AstAttrType::DIM_RIGHT, arguments[0],
+                                 arguments[1]);
         } else if (objectName == "$low") {
-          if (arguments.size() == 1)
-            arguments.push_back(nullptr);  // provide default for optional parameter
-          return new AstAttrOf(new FileLine("uhdm"),
-                               AstAttrType::DIM_LOW,
-                               arguments[0],
-                               arguments[1]);
+            if (arguments.size() == 1)
+                arguments.push_back(nullptr);  // provide default for optional parameter
+            return new AstAttrOf(new FileLine("uhdm"), AstAttrType::DIM_LOW, arguments[0],
+                                 arguments[1]);
         } else if (objectName == "$high") {
-          if (arguments.size() == 1)
-            arguments.push_back(nullptr);  // provide default for optional parameter
-          return new AstAttrOf(new FileLine("uhdm"),
-                               AstAttrType::DIM_HIGH,
-                               arguments[0],
-                               arguments[1]);
+            if (arguments.size() == 1)
+                arguments.push_back(nullptr);  // provide default for optional parameter
+            return new AstAttrOf(new FileLine("uhdm"), AstAttrType::DIM_HIGH, arguments[0],
+                                 arguments[1]);
         } else if (objectName == "$increment") {
-          if (arguments.size() == 1)
-            arguments.push_back(nullptr);  // provide default for optional parameter
-          return new AstAttrOf(new FileLine("uhdm"),
-                               AstAttrType::DIM_RIGHT,
-                               arguments[0],
-                               arguments[1]);
+            if (arguments.size() == 1)
+                arguments.push_back(nullptr);  // provide default for optional parameter
+            return new AstAttrOf(new FileLine("uhdm"), AstAttrType::DIM_RIGHT, arguments[0],
+                                 arguments[1]);
         } else if (objectName == "$size") {
-          if (arguments.size() == 1)
-            arguments.push_back(nullptr);  // provide default for optional parameter
-          return new AstAttrOf(new FileLine("uhdm"),
-                               AstAttrType::DIM_RIGHT,
-                               arguments[0],
-                               arguments[1]);
+            if (arguments.size() == 1)
+                arguments.push_back(nullptr);  // provide default for optional parameter
+            return new AstAttrOf(new FileLine("uhdm"), AstAttrType::DIM_RIGHT, arguments[0],
+                                 arguments[1]);
         } else if (objectName == "$dimensions") {
-          return new AstAttrOf(new FileLine("uhdm"),
-                               AstAttrType::DIM_DIMENSIONS,
-                               arguments[0]);
+            return new AstAttrOf(new FileLine("uhdm"), AstAttrType::DIM_DIMENSIONS, arguments[0]);
         } else if (objectName == "$unpacked_dimensions") {
-          return new AstAttrOf(new FileLine("uhdm"),
-                               AstAttrType::DIM_UNPK_DIMENSIONS,
-                               arguments[0]);
+            return new AstAttrOf(new FileLine("uhdm"), AstAttrType::DIM_UNPK_DIMENSIONS,
+                                 arguments[0]);
         } else if (objectName == "$bits") {
-          return new AstAttrOf(new FileLine("uhdm"),
-                               AstAttrType::DIM_BITS,
-                               arguments[0]);
+            return new AstAttrOf(new FileLine("uhdm"), AstAttrType::DIM_BITS, arguments[0]);
         } else if (objectName == "$realtobits") {
-          return new AstRealToBits(new FileLine("uhdm"),
-                                   arguments[0]);
+            return new AstRealToBits(new FileLine("uhdm"), arguments[0]);
         } else if (objectName == "$bitstoreal") {
-          return new AstBitsToRealD(new FileLine("uhdm"),
-                                    arguments[0]);
+            return new AstBitsToRealD(new FileLine("uhdm"), arguments[0]);
         } else if (objectName == "$readmemh") {
-          if (arguments.size() == 2) {
-            return new AstReadMem(new FileLine("uhdm"),
-                                  true, // isHex
-                                  arguments[0],
-                                  arguments[1],
-                                  nullptr,
-                                  nullptr);
-          } else if (arguments.size() ==4) {
-            return new AstReadMem(new FileLine("uhdm"),
-                                  true, // isHex
-                                  arguments[0],
-                                  arguments[1],
-                                  arguments[2],
-                                  arguments[3]);
-          }
+            if (arguments.size() == 2) {
+                return new AstReadMem(new FileLine("uhdm"),
+                                      true,  // isHex
+                                      arguments[0], arguments[1], nullptr, nullptr);
+            } else if (arguments.size() == 4) {
+                return new AstReadMem(new FileLine("uhdm"),
+                                      true,  // isHex
+                                      arguments[0], arguments[1], arguments[2], arguments[3]);
+            }
         } else if (objectName == "$readmemb") {
-          if (arguments.size() == 2) {
-            return new AstReadMem(new FileLine("uhdm"),
-                                  false, // isHex
-                                  arguments[0],
-                                  arguments[1],
-                                  nullptr,
-                                  nullptr);
-          } else if (arguments.size() ==4) {
-            return new AstReadMem(new FileLine("uhdm"),
-                                  false, // isHex
-                                  arguments[0],
-                                  arguments[1],
-                                  arguments[2],
-                                  arguments[3]);
-          }
-        } else if (objectName == "$info"
-                   || objectName == "$warning"
-                   || objectName == "$error"
-                   || objectName == "$fatal" ) {
+            if (arguments.size() == 2) {
+                return new AstReadMem(new FileLine("uhdm"),
+                                      false,  // isHex
+                                      arguments[0], arguments[1], nullptr, nullptr);
+            } else if (arguments.size() == 4) {
+                return new AstReadMem(new FileLine("uhdm"),
+                                      false,  // isHex
+                                      arguments[0], arguments[1], arguments[2], arguments[3]);
+            }
+        } else if (objectName == "$info" || objectName == "$warning" || objectName == "$error"
+                   || objectName == "$fatal") {
 
-          AstDisplayType type;
-          if (objectName == "$info") {
-            type = AstDisplayType::DT_INFO;
-          } else if (objectName == "$warning") {
-            type = AstDisplayType::DT_WARNING;
-          } else if (objectName == "$error") {
-            type = AstDisplayType::DT_ERROR;
-          } else if (objectName == "$fatal") {
-            type = AstDisplayType::DT_FATAL;
-            // Verilator discards the finish number - first argument
-            if (arguments.size())
-              arguments.erase(arguments.begin());
-          }
+            AstDisplayType type;
+            if (objectName == "$info") {
+                type = AstDisplayType::DT_INFO;
+            } else if (objectName == "$warning") {
+                type = AstDisplayType::DT_WARNING;
+            } else if (objectName == "$error") {
+                type = AstDisplayType::DT_ERROR;
+            } else if (objectName == "$fatal") {
+                type = AstDisplayType::DT_FATAL;
+                // Verilator discards the finish number - first argument
+                if (arguments.size()) arguments.erase(arguments.begin());
+            }
 
-          AstNode* args = nullptr;
-          for (auto a : arguments) {
-            if (args == nullptr)
-              args = a;
-            else
-              args->addNextNull(a);
-          }
-          node = new AstDisplay(new FileLine("uhdm"),
-                                type,
-                                nullptr,
-                                args);
-          if (type == AstDisplayType::DT_ERROR
-              || type == AstDisplayType::DT_FATAL) {
-            auto* stop = new AstStop(new FileLine("uhdm"),
-                                     (type == AstDisplayType::DT_ERROR));
-            node->addNext(stop);
-          }
-          return node;
+            AstNode* args = nullptr;
+            for (auto a : arguments) {
+                if (args == nullptr)
+                    args = a;
+                else
+                    args->addNextNull(a);
+            }
+            node = new AstDisplay(new FileLine("uhdm"), type, nullptr, args);
+            if (type == AstDisplayType::DT_ERROR || type == AstDisplayType::DT_FATAL) {
+                auto* stop = new AstStop(new FileLine("uhdm"), (type == AstDisplayType::DT_ERROR));
+                node->addNext(stop);
+            }
+            return node;
         } else if (objectName == "$__BAD_SYMBOL__") {
-          v3info("\t! Bad symbol encountered @ "
-                 << file_name << ":" << currentLine);
-          // Dummy statement to keep parsing
-          return new AstTime(new FileLine("uhdm"),
-              VTimescale::TS_1PS);  //TODO: revisit once we have it in UHDM
+            v3info("\t! Bad symbol encountered @ " << file_name << ":" << currentLine);
+            // Dummy statement to keep parsing
+            return new AstTime(new FileLine("uhdm"),
+                               VTimescale::TS_1PS);  // TODO: revisit once we have it in UHDM
         } else {
             v3error("\t! Encountered unhandled SysFuncCall: " << objectName);
         }
         auto parent_h = vpi_handle(vpiParent, obj_h);
         int parent_type = 0;
-        if (parent_h) {
-          parent_type = vpi_get(vpiType, parent_h);
-        }
-        if (parent_type == vpiBegin) { // TODO: Are other contexts missing here?
-          // In task-like context return values are discarded
-          // This is indicated by wrapping the node
-          return new AstSysFuncAsTask(new FileLine("uhdm"), node);
+        if (parent_h) { parent_type = vpi_get(vpiType, parent_h); }
+        if (parent_type == vpiBegin) {  // TODO: Are other contexts missing here?
+            // In task-like context return values are discarded
+            // This is indicated by wrapping the node
+            return new AstSysFuncAsTask(new FileLine("uhdm"), node);
         } else {
-          return node;
+            return node;
         }
-      }
-      case vpiRange: {
+    }
+    case vpiRange: {
         AstNode* msbNode = nullptr;
         AstNode* lsbNode = nullptr;
         AstRange* rangeNode = nullptr;
-        auto leftRange_h  = vpi_handle(vpiLeftRange, obj_h);
-        if (leftRange_h) {
-          msbNode = visit_object(leftRange_h, visited, top_nodes);
-        }
-        auto rightRange_h  = vpi_handle(vpiRightRange, obj_h);
-        if (rightRange_h) {
-          lsbNode = visit_object(rightRange_h, visited, top_nodes);
-        }
+        auto leftRange_h = vpi_handle(vpiLeftRange, obj_h);
+        if (leftRange_h) { msbNode = visit_object(leftRange_h, visited, top_nodes); }
+        auto rightRange_h = vpi_handle(vpiRightRange, obj_h);
+        if (rightRange_h) { lsbNode = visit_object(rightRange_h, visited, top_nodes); }
         if (msbNode && lsbNode) {
-          rangeNode = new AstRange(new FileLine("uhdm"), msbNode, lsbNode);
+            rangeNode = new AstRange(new FileLine("uhdm"), msbNode, lsbNode);
         }
         return rangeNode;
-      }
-      case vpiPartSelect: {
+    }
+    case vpiPartSelect: {
         AstNode* msbNode = nullptr;
         AstNode* lsbNode = nullptr;
         AstNode* fromNode = nullptr;
 
-        visit_one_to_one({
-            vpiLeftRange,
-            vpiRightRange,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (item) {
-              if (msbNode == nullptr) {
-                msbNode = item;
-              } else if (lsbNode == nullptr) {
-                lsbNode = item;
-              }
-            }
-          });
+        visit_one_to_one(
+            {
+                vpiLeftRange,
+                vpiRightRange,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (item) {
+                    if (msbNode == nullptr) {
+                        msbNode = item;
+                    } else if (lsbNode == nullptr) {
+                        lsbNode = item;
+                    }
+                }
+            });
         auto parent_h = vpi_handle(vpiParent, obj_h);
         if (parent_h != 0) {
-          std::string parent_name;
-          if (auto s = vpi_get_str(vpiName, parent_h))
-            parent_name = s;
-          sanitize_str(parent_name);
-          fromNode = new AstParseRef(new FileLine("uhdm"),
-                                  VParseRefExp::en::PX_TEXT,
-                                  parent_name,
-                                  nullptr,
-                                  nullptr);
+            std::string parent_name;
+            if (auto s = vpi_get_str(vpiName, parent_h)) parent_name = s;
+            sanitize_str(parent_name);
+            fromNode = new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT,
+                                       parent_name, nullptr, nullptr);
         }
         return new AstSelExtract(new FileLine("uhdm"), fromNode, msbNode, lsbNode);
-      }
-      case vpiIndexedPartSelect: {
+    }
+    case vpiIndexedPartSelect: {
         AstNode* bit = nullptr;
         AstNode* width = nullptr;
         AstNode* fromNode = nullptr;
 
-        visit_one_to_one({
-            vpiBaseExpr,
-            vpiWidthExpr,
-            vpiParent,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (item) {
-              if (bit == nullptr) {
-                bit = item;
-              } else if (width == nullptr) {
-                width = item;
-              }
-            }
-          });
+        visit_one_to_one(
+            {
+                vpiBaseExpr,
+                vpiWidthExpr,
+                vpiParent,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (item) {
+                    if (bit == nullptr) {
+                        bit = item;
+                    } else if (width == nullptr) {
+                        width = item;
+                    }
+                }
+            });
         auto parent_h = vpi_handle(vpiParent, obj_h);
         std::string parent_name = vpi_get_str(vpiName, parent_h);
         sanitize_str(parent_name);
-        fromNode = new AstParseRef(new FileLine("uhdm"),
-                                VParseRefExp::en::PX_TEXT,
-                                parent_name,
-                                nullptr,
-                                nullptr);
+        fromNode = new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT, parent_name,
+                                   nullptr, nullptr);
 
         auto type = vpi_get(vpiIndexedPartSelectType, obj_h);
         if (type == vpiPosIndexed) {
-          return new AstSelPlus(new FileLine("uhdm"), fromNode, bit, width);
+            return new AstSelPlus(new FileLine("uhdm"), fromNode, bit, width);
         } else if (type == vpiNegIndexed) {
-          return new AstSelMinus(new FileLine("uhdm"), fromNode, bit, width);
+            return new AstSelMinus(new FileLine("uhdm"), fromNode, bit, width);
         } else {
-          return nullptr;
+            return nullptr;
         }
-      }
-      case vpiFor: {
+    }
+    case vpiFor: {
         AstNode* initsp = nullptr;
         AstNode* condp = nullptr;
         AstNode* incsp = nullptr;
         AstNode* bodysp = nullptr;
-        visit_one_to_one({
-            vpiForInitStmt,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            initsp = item;
-          });
-        visit_one_to_many({
-            vpiForInitStmt,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (initsp == nullptr) {
-              initsp = item;
-            } else {
-              initsp->addNextNull(item);
-            }
-          });
-        visit_one_to_one({
-            vpiCondition,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (condp == nullptr) {
-              condp = item;
-            } else {
-              condp->addNextNull(item);
-            }
-          });
-        visit_one_to_one({
-            vpiForIncStmt,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            incsp = item;
-          });
-        visit_one_to_many({
-            vpiForIncStmt,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (incsp == nullptr) {
-              incsp = item;
-            } else {
-              incsp->addNextNull(item);
-            }
-          });
-        visit_one_to_one({
-            vpiStmt,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (bodysp == nullptr) {
-              bodysp = item;
-            } else {
-              bodysp->addNextNull(item);
-            }
-          });
+        visit_one_to_one(
+            {
+                vpiForInitStmt,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* item) { initsp = item; });
+        visit_one_to_many(
+            {
+                vpiForInitStmt,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (initsp == nullptr) {
+                    initsp = item;
+                } else {
+                    initsp->addNextNull(item);
+                }
+            });
+        visit_one_to_one(
+            {
+                vpiCondition,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (condp == nullptr) {
+                    condp = item;
+                } else {
+                    condp->addNextNull(item);
+                }
+            });
+        visit_one_to_one(
+            {
+                vpiForIncStmt,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* item) { incsp = item; });
+        visit_one_to_many(
+            {
+                vpiForIncStmt,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (incsp == nullptr) {
+                    incsp = item;
+                } else {
+                    incsp->addNextNull(item);
+                }
+            });
+        visit_one_to_one(
+            {
+                vpiStmt,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (bodysp == nullptr) {
+                    bodysp = item;
+                } else {
+                    bodysp->addNextNull(item);
+                }
+            });
         AstNode* loop = new AstWhile(new FileLine("uhdm"), condp, bodysp, incsp);
         initsp->addNextNull(loop);
         AstNode* stmt = new AstBegin(new FileLine("uhdm"), "", initsp);
         return stmt;
-      }
-      case vpiDoWhile:
-      case vpiWhile: {
+    }
+    case vpiDoWhile:
+    case vpiWhile: {
         AstNode* condp = nullptr;
         AstNode* bodysp = nullptr;
-        visit_one_to_one({
-            vpiCondition,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (condp == nullptr) {
-              condp = item;
-            } else {
-              condp->addNextNull(item);
-            }
-          });
-        visit_one_to_one({
-            vpiStmt,
-            }, obj_h, visited, top_nodes,
-          [&](AstNode* item){
-            if (bodysp == nullptr) {
-              bodysp = item;
-            } else {
-              bodysp->addNextNull(item);
-            }
-          });
+        visit_one_to_one(
+            {
+                vpiCondition,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (condp == nullptr) {
+                    condp = item;
+                } else {
+                    condp->addNextNull(item);
+                }
+            });
+        visit_one_to_one(
+            {
+                vpiStmt,
+            },
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (bodysp == nullptr) {
+                    bodysp = item;
+                } else {
+                    bodysp->addNextNull(item);
+                }
+            });
         AstNode* loop = new AstWhile(new FileLine("uhdm"), condp, bodysp);
         if (objectType == vpiWhile) {
-          return loop;
+            return loop;
         } else if (objectType == vpiDoWhile) {
-          auto* first_iter = bodysp->cloneTree(true);
-          first_iter->addNextNull(loop);
-          return first_iter;
+            auto* first_iter = bodysp->cloneTree(true);
+            first_iter->addNextNull(loop);
+            return first_iter;
         }
         break;
-      }
+    }
 
-      case vpiBitTypespec: {
+    case vpiBitTypespec: {
         AstRange* rangeNode = nullptr;
         visit_one_to_many({vpiRange}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              rangeNode = reinterpret_cast<AstRange*>(node);
-            });
-        auto* dtype = new AstBasicDType(new FileLine("uhdm"),
-                                        AstBasicDTypeKwd::BIT);
+                          [&](AstNode* node) { rangeNode = reinterpret_cast<AstRange*>(node); });
+        auto* dtype = new AstBasicDType(new FileLine("uhdm"), AstBasicDTypeKwd::BIT);
         dtype->rangep(rangeNode);
         return dtype;
-      }
-      case vpiLogicTypespec: {
+    }
+    case vpiLogicTypespec: {
         AstRange* rangeNode = nullptr;
         visit_one_to_many({vpiRange}, obj_h, visited, top_nodes,
-            [&](AstNode* node){
-              rangeNode = reinterpret_cast<AstRange*>(node);
-            });
-        auto* dtype = new AstBasicDType(new FileLine("uhdm"),
-                                  AstBasicDTypeKwd::LOGIC);
+                          [&](AstNode* node) { rangeNode = reinterpret_cast<AstRange*>(node); });
+        auto* dtype = new AstBasicDType(new FileLine("uhdm"), AstBasicDTypeKwd::LOGIC);
         dtype->rangep(rangeNode);
         return dtype;
-      }
-      case vpiIntTypespec: {
+    }
+    case vpiIntTypespec: {
         auto* name = vpi_get_str(vpiName, obj_h);
         if (name == nullptr) {
-          auto* dtype = new AstBasicDType(new FileLine("uhdm"),
-                                          AstBasicDTypeKwd::INT);
-          return dtype;
+            auto* dtype = new AstBasicDType(new FileLine("uhdm"), AstBasicDTypeKwd::INT);
+            return dtype;
         }
-        return new AstParseRef(new FileLine("uhdm"),
-			               VParseRefExp::en::PX_TEXT,
-			               name,
-				       nullptr,
-				       nullptr);
-      }
-      case vpiStringTypespec: {
-        auto* dtype = new AstBasicDType(new FileLine("uhdm"),
-                                        AstBasicDTypeKwd::STRING);
+        return new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT, name, nullptr,
+                               nullptr);
+    }
+    case vpiStringTypespec: {
+        auto* dtype = new AstBasicDType(new FileLine("uhdm"), AstBasicDTypeKwd::STRING);
         return dtype;
-      }
-      case vpiIntegerTypespec: {
+    }
+    case vpiIntegerTypespec: {
         AstNode* constNode = get_value_as_node(obj_h);
         if (constNode == nullptr) {
-          v3info("Valueless typepec, returning dtype");
-          auto* dtype = new AstBasicDType(new FileLine("uhdm"),
-                                          AstBasicDTypeKwd::INTEGER);
-          return dtype;
+            v3info("Valueless typepec, returning dtype");
+            auto* dtype = new AstBasicDType(new FileLine("uhdm"), AstBasicDTypeKwd::INTEGER);
+            return dtype;
         }
         return constNode;
-      }
-      case vpiVoidTypespec: {
+    }
+    case vpiVoidTypespec: {
         return new AstVoidDType(new FileLine("uhdm"));
-      }
-      case vpiEnumTypespec: {
-        const uhdm_handle* const handle = (const uhdm_handle*) obj_h;
-        const UHDM::BaseClass* const object = (const UHDM::BaseClass*) handle->object;
+    }
+    case vpiEnumTypespec: {
+        const uhdm_handle* const handle = (const uhdm_handle*)obj_h;
+        const UHDM::BaseClass* const object = (const UHDM::BaseClass*)handle->object;
         if (visited_types.find(object) != visited_types.end()) {
-          // Already seen this, do not create a duplicate
-          // References are handled using getDType, not in visit_object
-          return nullptr;
+            // Already seen this, do not create a duplicate
+            // References are handled using getDType, not in visit_object
+            return nullptr;
         }
 
         visited_types[object] = package_prefix + objectName;
@@ -2855,372 +2469,284 @@ namespace UhdmAst {
         AstNodeDType* enum_member_dtype = nullptr;
 
         vpiHandle itr = vpi_iterate(vpiEnumConst, obj_h);
-        while (vpiHandle item_h = vpi_scan(itr) ) {
-          auto* value = get_value_as_node(item_h);
-          std::string item_name;
-          if (auto s = vpi_get_str(vpiName, item_h)) {
-            item_name = s;
-            sanitize_str(item_name);
-          }
-          auto* wrapped_item = new AstEnumItem(new FileLine("uhdm"),
-                                               item_name,
-                                               nullptr,
-                                               value);
-          if (enum_members == nullptr) {
-            enum_members = wrapped_item;
-          } else {
-            enum_members->addNextNull(wrapped_item);
-          }
+        while (vpiHandle item_h = vpi_scan(itr)) {
+            auto* value = get_value_as_node(item_h);
+            std::string item_name;
+            if (auto s = vpi_get_str(vpiName, item_h)) {
+                item_name = s;
+                sanitize_str(item_name);
+            }
+            auto* wrapped_item = new AstEnumItem(new FileLine("uhdm"), item_name, nullptr, value);
+            if (enum_members == nullptr) {
+                enum_members = wrapped_item;
+            } else {
+                enum_members->addNextNull(wrapped_item);
+            }
         }
         vpi_free_object(itr);
 
-        visit_one_to_one({
-            vpiBaseTypespec
-            },
-            obj_h,
-            visited,
-            top_nodes,
-            [&](AstNode* item) {
-              if (item != nullptr) {
-                enum_member_dtype = reinterpret_cast<AstNodeDType*>(item);
-              }
-            });
+        visit_one_to_one({vpiBaseTypespec}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item != nullptr) { enum_member_dtype = reinterpret_cast<AstNodeDType*>(item); }
+        });
         if (enum_member_dtype == nullptr) {
-          // No data type specified, use default
-          enum_member_dtype = new AstBasicDType(new FileLine("uhdm"),
-                                                AstBasicDTypeKwd::INT);
+            // No data type specified, use default
+            enum_member_dtype = new AstBasicDType(new FileLine("uhdm"), AstBasicDTypeKwd::INT);
         }
-        auto* enum_dtype = new AstEnumDType(new FileLine("uhdm"),
-                                            VFlagChildDType(),
-                                            enum_member_dtype,
-                                            enum_members);
-        auto* dtype = new AstDefImplicitDType(new FileLine("uhdm"),
-                                              objectName,
-                                              nullptr,
-                                              VFlagChildDType(),
-                                              enum_dtype);
-        auto* enum_type = new AstTypedef(new FileLine("uhdm"),
-                                         objectName,
-                                         nullptr,
-                                         VFlagChildDType(),
-                                         dtype);
+        auto* enum_dtype = new AstEnumDType(new FileLine("uhdm"), VFlagChildDType(),
+                                            enum_member_dtype, enum_members);
+        auto* dtype = new AstDefImplicitDType(new FileLine("uhdm"), objectName, nullptr,
+                                              VFlagChildDType(), enum_dtype);
+        auto* enum_type
+            = new AstTypedef(new FileLine("uhdm"), objectName, nullptr, VFlagChildDType(), dtype);
         m_symp->reinsert(enum_type);
         return enum_type;
-      }
-      case vpiStructTypespec: {
-        const uhdm_handle* const handle = (const uhdm_handle*) obj_h;
-        const UHDM::BaseClass* const object = (const UHDM::BaseClass*) handle->object;
+    }
+    case vpiStructTypespec: {
+        const uhdm_handle* const handle = (const uhdm_handle*)obj_h;
+        const UHDM::BaseClass* const object = (const UHDM::BaseClass*)handle->object;
         if (visited_types.find(object) != visited_types.end()) {
-          UINFO(6, "Object " << objectName << " was already visited" << std::endl);
-          return node;
+            UINFO(6, "Object " << objectName << " was already visited" << std::endl);
+            return node;
         }
         visited_types[object] = package_prefix + objectName;
         // VSigning below is used in AstStructDtype to indicate
         // if packed or not
         VSigning packed;
         if (vpi_get(vpiPacked, obj_h)) {
-          packed = VSigning::SIGNED;
+            packed = VSigning::SIGNED;
         } else {
-          packed = VSigning::UNSIGNED;
+            packed = VSigning::UNSIGNED;
         }
-        auto* struct_dtype = new AstStructDType(new FileLine("uhdm"),
-                                                packed);
-        visit_one_to_many({vpiTypespecMember}, obj_h, visited, top_nodes,
-            [&](AstNode* item) {
-              if (item != nullptr) {
-                struct_dtype->addMembersp(item);
-              }
-            });
-        auto* dtype = new AstDefImplicitDType(new FileLine("uhdm"),
-                                              objectName,
-                                              nullptr,
-                                              VFlagChildDType(),
-                                              struct_dtype);
-        auto* struct_type = new AstTypedef(new FileLine("uhdm"),
-                                           objectName,
-                                           nullptr,
-                                           VFlagChildDType(),
-                                           dtype);
+        auto* struct_dtype = new AstStructDType(new FileLine("uhdm"), packed);
+        visit_one_to_many({vpiTypespecMember}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item != nullptr) { struct_dtype->addMembersp(item); }
+        });
+        auto* dtype = new AstDefImplicitDType(new FileLine("uhdm"), objectName, nullptr,
+                                              VFlagChildDType(), struct_dtype);
+        auto* struct_type
+            = new AstTypedef(new FileLine("uhdm"), objectName, nullptr, VFlagChildDType(), dtype);
         m_symp->reinsert(struct_type);
         return struct_type;
-      }
-      case vpiTypespecMember: {
+    }
+    case vpiTypespecMember: {
         AstNodeDType* typespec = nullptr;
         auto typespec_h = vpi_handle(vpiTypespec, obj_h);
         typespec = getDType(typespec_h, visited, top_nodes);
         if (typespec != nullptr) {
-          auto * member =  new AstMemberDType(new FileLine("uhdm"),
-              objectName,
-              VFlagChildDType(),
-              reinterpret_cast<AstNodeDType*>(typespec));
-          return member;
+            auto* member = new AstMemberDType(new FileLine("uhdm"), objectName, VFlagChildDType(),
+                                              reinterpret_cast<AstNodeDType*>(typespec));
+            return member;
         }
         return nullptr;
-      }
-      case vpiTypeParameter: {
+    }
+    case vpiTypeParameter: {
         AstNodeDType* dtype = nullptr;
-        visit_one_to_one({vpiTypespec}, obj_h, visited, top_nodes,
-            [&](AstNode* item) {
-              if (item != nullptr) {
-                dtype = reinterpret_cast<AstNodeDType*>(item);
-              }
-            });
-        auto *ast_typedef = new AstTypedef(new FileLine("uhdm"),
-                              objectName,
-                              nullptr,
-                              VFlagChildDType(),
-                              dtype);
+        visit_one_to_one({vpiTypespec}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item != nullptr) { dtype = reinterpret_cast<AstNodeDType*>(item); }
+        });
+        auto* ast_typedef
+            = new AstTypedef(new FileLine("uhdm"), objectName, nullptr, VFlagChildDType(), dtype);
         m_symp->reinsert(ast_typedef);
         return ast_typedef;
-      }
-      case vpiLogicVar:
-      case vpiStringVar:
-      case vpiTimeVar:
-      case vpiRealVar:
-      case vpiIntVar:
-      case vpiLongIntVar:
-      case vpiIntegerVar:
-      case vpiEnumVar:
-      case vpiBitVar:
-      case vpiByteVar: {
+    }
+    case vpiLogicVar:
+    case vpiStringVar:
+    case vpiTimeVar:
+    case vpiRealVar:
+    case vpiIntVar:
+    case vpiLongIntVar:
+    case vpiIntegerVar:
+    case vpiEnumVar:
+    case vpiBitVar:
+    case vpiByteVar: {
         AstNodeDType* dtype = getDType(obj_h, visited, top_nodes);
-        auto* var = new AstVar(new FileLine("uhdm"),
-                         AstVarType::VAR,
-                         objectName,
-                         VFlagChildDType(),
-                         dtype);
+        auto* var = new AstVar(new FileLine("uhdm"), AstVarType::VAR, objectName,
+                               VFlagChildDType(), dtype);
         visit_one_to_one({vpiExpr}, obj_h, visited, top_nodes,
-            [&](AstNode* item) {
-              var->valuep(item);
-            });
+                         [&](AstNode* item) { var->valuep(item); });
         return var;
-      }
-      case vpiPackedArrayVar:
-      case vpiArrayVar: {
+    }
+    case vpiPackedArrayVar:
+    case vpiArrayVar: {
         auto dtype = getDType(obj_h, visited, top_nodes);
 
-        auto* var = new AstVar(new FileLine("uhdm"),
-                         AstVarType::VAR,
-                         objectName,
-                         VFlagChildDType(),
-                         dtype);
+        auto* var = new AstVar(new FileLine("uhdm"), AstVarType::VAR, objectName,
+                               VFlagChildDType(), dtype);
         return var;
-      }
-      case vpiChandleVar: {
-        auto* dtype = new AstBasicDType(new FileLine("uhdm"),
-                                        AstBasicDTypeKwd::CHANDLE);
-        auto* var = new AstVar(new FileLine("uhdm"),
-                               AstVarType::VAR,
-                               objectName,
-                               VFlagChildDType(),
-                               dtype);
+    }
+    case vpiChandleVar: {
+        auto* dtype = new AstBasicDType(new FileLine("uhdm"), AstBasicDTypeKwd::CHANDLE);
+        auto* var = new AstVar(new FileLine("uhdm"), AstVarType::VAR, objectName,
+                               VFlagChildDType(), dtype);
         return var;
-      }
-      case vpiGenScopeArray: {
+    }
+    case vpiGenScopeArray: {
         AstNode* statements = nullptr;
-        visit_one_to_many({
-            vpiGenScope
-            },
-            obj_h,
-            visited,
-            top_nodes,
-            [&](AstNode* item) {
-              if (statements == nullptr) {
+        visit_one_to_many({vpiGenScope}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (statements == nullptr) {
                 statements = item;
-              } else {
+            } else {
                 statements->addNextNull(item);
-              }
-            });
+            }
+        });
         return new AstBegin(new FileLine("uhdm"), "", statements);
-      }
-      case vpiGenScope: {
+    }
+    case vpiGenScope: {
         AstNode* statements = nullptr;
-        visit_one_to_many({
-            vpiTypedef,
-            vpiInternalScope,
-            vpiArrayNet,
-            //vpiLogicVar,
-            //vpiArrayVar,
-            vpiMemory,
-            vpiVariables,
-            vpiNet,
-            vpiNamedEvent,
-            vpiNamedEventArray,
-            vpiProcess,
-            vpiContAssign,
-            vpiModule,
-            vpiModuleArray,
-            vpiPrimitive,
-            vpiPrimitiveArray,
-            vpiDefParam,
-            vpiParameter,
-            vpiParamAssign,
-            vpiGenScopeArray,
-            vpiProgram,
-            vpiProgramArray,
-            //vpiAssertion,
-            vpiInterface,
-            vpiInterfaceArray,
-            vpiAliasStmt,
-            vpiClockingBlock,
+        visit_one_to_many(
+            {
+                vpiTypedef,
+                vpiInternalScope,
+                vpiArrayNet,
+                // vpiLogicVar,
+                // vpiArrayVar,
+                vpiMemory,
+                vpiVariables,
+                vpiNet,
+                vpiNamedEvent,
+                vpiNamedEventArray,
+                vpiProcess,
+                vpiContAssign,
+                vpiModule,
+                vpiModuleArray,
+                vpiPrimitive,
+                vpiPrimitiveArray,
+                vpiDefParam,
+                vpiParameter,
+                vpiParamAssign,
+                vpiGenScopeArray,
+                vpiProgram,
+                vpiProgramArray,
+                // vpiAssertion,
+                vpiInterface,
+                vpiInterfaceArray,
+                vpiAliasStmt,
+                vpiClockingBlock,
             },
-            obj_h,
-            visited,
-            top_nodes,
-            [&](AstNode* item) {
-              if (statements == nullptr) {
-                statements = item;
-              } else {
-                statements->addNextNull(item);
-              }
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (statements == nullptr) {
+                    statements = item;
+                } else {
+                    statements->addNextNull(item);
+                }
             });
         return statements;
-      }
-      case vpiDelayControl: {
+    }
+    case vpiDelayControl: {
         s_vpi_delay delay;
         vpi_get_delays(obj_h, &delay);
 
         // Verilator ignores delay statements, just grab the first one for simplicity
         if (delay.da != nullptr) {
-          auto* delay_c = new AstConst(new FileLine("uhdm"), delay.da[0].real);
-          return new AstDelay(new FileLine("uhdm"), delay_c);
+            auto* delay_c = new AstConst(new FileLine("uhdm"), delay.da[0].real);
+            return new AstDelay(new FileLine("uhdm"), delay_c);
         }
-      }
-      case vpiBreak: {
+    }
+    case vpiBreak: {
         return new AstBreak(new FileLine("uhdm"));
-      }
-      case vpiForeachStmt: {
-        AstNode* arrayp = nullptr; // Array, then index variables
+    }
+    case vpiForeachStmt: {
+        AstNode* arrayp = nullptr;  // Array, then index variables
         AstNode* bodyp = nullptr;
-        visit_one_to_one({vpiVariables}, obj_h, visited, top_nodes,
-            [&](AstNode* item) {
-              if (arrayp == nullptr) {
+        visit_one_to_one({vpiVariables}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (arrayp == nullptr) {
                 arrayp = item;
-              } else {
+            } else {
                 arrayp->addNextNull(item);
-              }
-            });
-        visit_one_to_many({vpiLoopVars}, obj_h, visited, top_nodes,
-            [&](AstNode* item) {
-              if (arrayp == nullptr) {
+            }
+        });
+        visit_one_to_many({vpiLoopVars}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (arrayp == nullptr) {
                 arrayp = item;
-              } else {
+            } else {
                 arrayp->addNextNull(item);
-              }
-            });
-        visit_one_to_many({vpiStmt}, obj_h, visited, top_nodes,
-            [&](AstNode* item) {
-              if (bodyp == nullptr) {
+            }
+        });
+        visit_one_to_many({vpiStmt}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (bodyp == nullptr) {
                 bodyp = item;
-              } else {
+            } else {
                 bodyp->addNextNull(item);
-              }
-            });
+            }
+        });
         return new AstForeach(new FileLine("uhdm"), arrayp, bodyp);
-      }
-      case vpiMethodFuncCall: {
+    }
+    case vpiMethodFuncCall: {
         AstNode* from = nullptr;
         AstNode* args = nullptr;
         visit_one_to_one({vpiPrefix}, obj_h, visited, top_nodes,
-            [&](AstNode* item) {
-                from = item;
-            });
+                         [&](AstNode* item) { from = item; });
         if (from == nullptr) {
-          from = new AstParseRef(new FileLine("uhdm"),
-                                              VParseRefExp::en::PX_TEXT,
-                                              "this",
-                                              nullptr,
-                                              nullptr);
+            from = new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT, "this",
+                                   nullptr, nullptr);
         }
-        visit_one_to_many({vpiArgument}, obj_h, visited, top_nodes,
-            [&](AstNode* item) {
-              if (args == nullptr) {
+        visit_one_to_many({vpiArgument}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (args == nullptr) {
                 args = item;
-              } else {
+            } else {
                 args->addNextNull(item);
-              }
-            });
+            }
+        });
         return new AstMethodCall(new FileLine("uhdm"), from, objectName, args);
-      }
-      // What we can see (but don't support yet)
-      case vpiClassObj:
-        break;
-      case vpiClassDefn: {
+    }
+    // What we can see (but don't support yet)
+    case vpiClassObj: break;
+    case vpiClassDefn: {
         auto* definition = new AstClass(new FileLine("uhdm"), objectName);
-        visit_one_to_many({
-            vpiTypedef,
-            vpiVariables,
-            //vpiMethods,  // Not supported yet in UHDM
-            vpiConstraint,
-            vpiParameter,
-            vpiNamedEvent,
-            vpiNamedEventArray,
-            vpiInternalScope,
+        visit_one_to_many(
+            {
+                vpiTypedef,
+                vpiVariables,
+                // vpiMethods,  // Not supported yet in UHDM
+                vpiConstraint,
+                vpiParameter,
+                vpiNamedEvent,
+                vpiNamedEventArray,
+                vpiInternalScope,
             },
-            obj_h,
-            visited,
-            top_nodes,
-            [&](AstNode* item) {
-              if (item != nullptr) {
-                definition->addMembersp(item);
-              }
+            obj_h, visited, top_nodes, [&](AstNode* item) {
+                if (item != nullptr) { definition->addMembersp(item); }
             });
         return definition;
-      }
-      case vpiImmediateAssert: {
+    }
+    case vpiImmediateAssert: {
         AstAssert* assert = nullptr;
-        visit_one_to_one({vpiExpr},
-                          obj_h,
-                          visited,
-                          top_nodes,
-                          [&](AstNode* item) {
-                            if (item != nullptr) {
-                              assert = new AstAssert(new FileLine("uhdm"),
-                                                     item,
-                                                     nullptr,
-                                                     nullptr,
-                                                     true);
-                            }
-                        });
+        visit_one_to_one({vpiExpr}, obj_h, visited, top_nodes, [&](AstNode* item) {
+            if (item != nullptr) {
+                assert = new AstAssert(new FileLine("uhdm"), item, nullptr, nullptr, true);
+            }
+        });
         return assert;
-      }
-      case vpiUnsupportedTypespec: {
-        v3info("\t! This typespec is unsupported in UHDM: "
-               << file_name << ":" << currentLine);
+    }
+    case vpiUnsupportedTypespec: {
+        v3info("\t! This typespec is unsupported in UHDM: " << file_name << ":" << currentLine);
         // Create a reference and try to resolve later
-        return new AstParseRef(new FileLine("uhdm"),
-                               VParseRefExp::en::PX_TEXT,
-                               objectName,
-                               nullptr,
-                               nullptr);
-      }
-      case vpiUnsupportedStmt:
-        v3info("\t! This statement is unsupported in UHDM: "
-               << file_name << ":" << currentLine);
+        return new AstParseRef(new FileLine("uhdm"), VParseRefExp::en::PX_TEXT, objectName,
+                               nullptr, nullptr);
+    }
+    case vpiUnsupportedStmt:
+        v3info("\t! This statement is unsupported in UHDM: " << file_name << ":" << currentLine);
         // Dummy statement to keep parsing
         return new AstTime(new FileLine("uhdm"),
-              VTimescale::TS_1PS);  //TODO: revisit once we have it in UHDM
+                           VTimescale::TS_1PS);  // TODO: revisit once we have it in UHDM
         break;
-      case vpiUnsupportedExpr:
-        v3info("\t! This expression is unsupported in UHDM: "
-               << file_name << ":" << currentLine);
+    case vpiUnsupportedExpr:
+        v3info("\t! This expression is unsupported in UHDM: " << file_name << ":" << currentLine);
         // Dummy expression to keep parsing
         return new AstConst(new FileLine("uhdm"), 1);
         break;
-      default: {
+    default: {
         // Notify we have something unhandled
-        v3error("\t! Unhandled type: " << objectType
-            << ":" << UHDM::VpiTypeName(obj_h));
+        v3error("\t! Unhandled type: " << objectType << ":" << UHDM::VpiTypeName(obj_h));
         break;
-      }
+    }
     }
 
     return nullptr;
-  }
+}
 
-  std::vector<AstNodeModule*> visit_designs (const std::vector<vpiHandle>& designs,
-                                             std::ostream& coverage_report_stream,
-                                             V3ParseSym* symp) {
+std::vector<AstNodeModule*> visit_designs(const std::vector<vpiHandle>& designs,
+                                          std::ostream& coverage_report_stream, V3ParseSym* symp) {
     m_symp = symp;
     std::set<const UHDM::BaseClass*> visited;
     std::map<std::string, AstNodeModule*> top_nodes;
@@ -3228,59 +2754,49 @@ namespace UhdmAst {
     // Created and added only if there are classes in the design
     AstPackage* class_package = nullptr;
     for (auto design : designs) {
-        visit_one_to_many({
-            UHDM::uhdmallPackages,  // Keep this first, packages need to be defined before any imports
-            //UHDM::uhdmallClasses,
-            UHDM::uhdmallInterfaces,
-            UHDM::uhdmallModules,
-            UHDM::uhdmtopModules
-            },
-            design,
-            visited,
-            &top_nodes,
-            [&](AstNode* module) {
-              if (module != nullptr) {
-              // Top level nodes need to be NodeModules (created from design)
-              // This is true as we visit only top modules and interfaces (with the same AST node) above
-              top_nodes[module->name()] = (reinterpret_cast<AstNodeModule*>(module));
-              }
-              for (auto entry : coverage_set) {
-                coverage_report_stream << std::get<0>(entry)
-                                << ":" << std::get<1>(entry)
-                                << ":" << std::get<2>(entry) << std::endl;
-              }
-              coverage_set.clear();
-            });
+        visit_one_to_many({UHDM::uhdmallPackages,  // Keep this first, packages need to be defined
+                                                   // before any imports
+                           // UHDM::uhdmallClasses,
+                           UHDM::uhdmallInterfaces, UHDM::uhdmallModules, UHDM::uhdmtopModules},
+                          design, visited, &top_nodes, [&](AstNode* module) {
+                              if (module != nullptr) {
+                                  // Top level nodes need to be NodeModules (created from design)
+                                  // This is true as we visit only top modules and interfaces (with
+                                  // the same AST node) above
+                                  top_nodes[module->name()]
+                                      = (reinterpret_cast<AstNodeModule*>(module));
+                              }
+                              for (auto entry : coverage_set) {
+                                  coverage_report_stream << std::get<0>(entry) << ":"
+                                                         << std::get<1>(entry) << ":"
+                                                         << std::get<2>(entry) << std::endl;
+                              }
+                              coverage_set.clear();
+                          });
         // Top level class definitions
-        visit_one_to_many({
-            UHDM::uhdmallClasses,
+        visit_one_to_many(
+            {
+                UHDM::uhdmallClasses,
             },
-            design,
-            visited,
-            &top_nodes,
-            [&](AstNode* class_def) {
-              if (class_def != nullptr) {
-                if (class_package == nullptr) {
-                  class_package = new AstPackage(new FileLine("uhdm"), "AllClasses");
+            design, visited, &top_nodes, [&](AstNode* class_def) {
+                if (class_def != nullptr) {
+                    if (class_package == nullptr) {
+                        class_package = new AstPackage(new FileLine("uhdm"), "AllClasses");
+                    }
+                    UINFO(6, "Adding class " << class_def->name() << std::endl);
+                    class_package->addStmtp(class_def);
                 }
-                UINFO(6, "Adding class " << class_def->name() << std::endl);
-                class_package->addStmtp(class_def);
-              }
-              for (auto entry : coverage_set) {
-                coverage_report_stream << std::get<0>(entry)
-                                << ":" << std::get<1>(entry)
-                                << ":" << std::get<2>(entry) << std::endl;
-              }
-              coverage_set.clear();
+                for (auto entry : coverage_set) {
+                    coverage_report_stream << std::get<0>(entry) << ":" << std::get<1>(entry)
+                                           << ":" << std::get<2>(entry) << std::endl;
+                }
+                coverage_set.clear();
             });
     }
     std::vector<AstNodeModule*> nodes;
-    for (auto node : top_nodes)
-              nodes.push_back(node.second);
-    if (class_package != nullptr) {
-      nodes.push_back(class_package);
-    }
+    for (auto node : top_nodes) nodes.push_back(node.second);
+    if (class_package != nullptr) { nodes.push_back(class_package); }
     return nodes;
-  }
-
 }
+
+}  // namespace UhdmAst

--- a/src/UhdmAst.h
+++ b/src/UhdmAst.h
@@ -10,9 +10,25 @@
 
 namespace UhdmAst {
 
+typedef std::map<std::string, AstNode*> NameNodeMap;
+
+// Variables that need to be accessed by multiple nodes in the design
+struct UhdmShared {
+    std::map<std::string, AstPackage*> package_map;
+    std::string package_prefix;
+    NameNodeMap partial_modules;
+    std::unordered_map<const UHDM::BaseClass*, std::string> visited_types;
+    // Store parameters here (values can be updated for each instance)
+    // Final values will be added in respective module/package
+    std::map<std::string, NameNodeMap> top_param_map;
+    std::set<std::tuple<std::string, int, std::string>> coverage_set;
+    V3ParseSym* m_symp;
+
+    std::map<std::string, AstNodeModule*> top_nodes;
+};
+
 // Visits single VPI object and creates proper AST node
-AstNode* visit_object(vpiHandle obj_h, std::set<const UHDM::BaseClass*> visited,
-                      std::map<std::string, AstNodeModule*>* top_nodes);
+AstNode* visit_object(vpiHandle obj_h, UhdmShared& shared);
 
 // Visits all VPI design objects and returns created ASTs
 std::vector<AstNodeModule*> visit_designs(const std::vector<vpiHandle>& designs,

--- a/src/UhdmAst.h
+++ b/src/UhdmAst.h
@@ -10,14 +10,12 @@
 
 namespace UhdmAst {
 
-  // Visits single VPI object and creates proper AST node
-  AstNode* visit_object (vpiHandle obj_h,
-        std::set<const UHDM::BaseClass*> visited,
-        std::map<std::string, AstNodeModule*>* top_nodes);
+// Visits single VPI object and creates proper AST node
+AstNode* visit_object(vpiHandle obj_h, std::set<const UHDM::BaseClass*> visited,
+                      std::map<std::string, AstNodeModule*>* top_nodes);
 
-  // Visits all VPI design objects and returns created ASTs
-  std::vector<AstNodeModule*> visit_designs (const std::vector<vpiHandle>& designs,
-                                             std::ostream& coverage_report_stream,
-                                             V3ParseSym* symp);
-}
+// Visits all VPI design objects and returns created ASTs
+std::vector<AstNodeModule*> visit_designs(const std::vector<vpiHandle>& designs,
+                                          std::ostream& coverage_report_stream, V3ParseSym* symp);
+}  // namespace UhdmAst
 #endif  // Guard

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -61,7 +61,7 @@ void V3Global::readFiles() {
     VInFilter filter(v3Global.opt.pipeFilter());
     V3ParseSym parseSyms(v3Global.rootp());  // Symbol table must be common across all parsing
 
-    if(v3Global.opt.uhdmAst()) {
+    if (v3Global.opt.uhdmAst()) {
         // Use UHDM frontend
         const V3StringList& vFiles = v3Global.opt.vFiles();
         UHDM::Serializer serializer;
@@ -73,7 +73,7 @@ void V3Global::readFiles() {
         for (auto file : vFiles) {
             std::vector<vpiHandle> restoredDesigns = serializer.Restore(file);
 
-            if(v3Global.opt.dumpUhdm()) {
+            if (v3Global.opt.dumpUhdm()) {
                 std::cout << UHDM::visit_designs(restoredDesigns) << std::endl;
             }
             uhdm_lines_dump << UHDM::dump_visited(restoredDesigns);
@@ -93,7 +93,7 @@ void V3Global::readFiles() {
             }
 
             /* Add to design */
-            AstNetlist *designRoot = v3Global.rootp();
+            AstNetlist* designRoot = v3Global.rootp();
             for (auto itr = modules.begin(); itr != modules.end(); ++itr) {
                 designRoot->addModulep(*itr);
             }
@@ -101,36 +101,36 @@ void V3Global::readFiles() {
     } else if (v3Global.opt.uhdmAstSv()) {
         // Use UHDM-SV frontend
         const V3StringList& vFiles = v3Global.opt.vFiles();
-	V3StringList svFiles;
-	V3StringList uhdmFiles;
+        V3StringList svFiles;
+        V3StringList uhdmFiles;
 
         for (auto file : vFiles) {
-	    std::string::size_type ext_idx;
-	    std::string ext;
-	    ext_idx = file.rfind('.');
+            std::string::size_type ext_idx;
+            std::string ext;
+            ext_idx = file.rfind('.');
 
-	    if(ext_idx != std::string::npos) {
-	        ext = file.substr(ext_idx+1);
-	    } else {
-	       return;
-	    }
+            if (ext_idx != std::string::npos) {
+                ext = file.substr(ext_idx + 1);
+            } else {
+                return;
+            }
 
-	    if (ext == "sv" || ext == "vlt") {
-		    svFiles.push_back(file);
-	    } else if (ext == "uhdm") {
-		    uhdmFiles.push_back(file);
-	    } else {
-		    //return;
-	    }
-	}
+            if (ext == "sv" || ext == "vlt") {
+                svFiles.push_back(file);
+            } else if (ext == "uhdm") {
+                uhdmFiles.push_back(file);
+            } else {
+                // return;
+            }
+        }
 
-	for (auto uhdmFile : uhdmFiles) {
+        for (auto uhdmFile : uhdmFiles) {
             UHDM::Serializer serializer;
             std::vector<AstNodeModule*> modules;
             std::vector<vpiHandle> restoredDesigns = serializer.Restore(uhdmFile);
             std::ostringstream uhdm_lines_dump;
 
-	    if(v3Global.opt.dumpUhdm()) {
+            if (v3Global.opt.dumpUhdm()) {
                 std::cout << UHDM::visit_designs(restoredDesigns) << std::endl;
             }
 
@@ -139,24 +139,23 @@ void V3Global::readFiles() {
             std::ostringstream dummy;
             modules = UhdmAst::visit_designs(restoredDesigns, dummy, &parseSyms);
 
-            AstNetlist *designRoot = v3Global.rootp();
+            AstNetlist* designRoot = v3Global.rootp();
             for (auto itr = modules.begin(); itr != modules.end(); ++itr) {
                 designRoot->addModulep(*itr);
             }
-	}
-	V3Parse parser(v3Global.rootp(), &filter, &parseSyms);
+        }
+        V3Parse parser(v3Global.rootp(), &filter, &parseSyms);
 
-	for (auto svFile : svFiles) {
-		    parser.parseFile(new FileLine(FileLine::commandLineFilename()), svFile, false,
+        for (auto svFile : svFiles) {
+            parser.parseFile(new FileLine(FileLine::commandLineFilename()), svFile, false,
                              "Cannot find file containing module: ");
-	}
+        }
 
         const V3StringSet& libraryFiles = v3Global.opt.libraryFiles();
         for (const string& filename : libraryFiles) {
             parser.parseFile(new FileLine(FileLine::commandLineFilename()), filename, true,
                              "Cannot find file containing library module: ");
         }
-
 
     } else {
         // Use standard Verilator frontend
@@ -176,7 +175,7 @@ void V3Global::readFiles() {
         for (const string& filename : libraryFiles) {
             parser.parseFile(new FileLine(FileLine::commandLineFilename()), filename, true,
                              "Cannot find file containing library module: ");
-            }
+        }
     }
     // v3Global.rootp()->dumpTreeFile(v3Global.debugFilename("parse.tree"));
     V3Error::abortIfErrors();

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1046,7 +1046,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
                 m_ignc = flag;
             } else if (onoff(sw, "-inhibit-sim", flag /*ref*/)) {
                 m_inhibitSim = flag;
-            } else if ( onoff (sw, "-json-ast", flag/*ref*/)) {
+            } else if (onoff(sw, "-json-ast", flag /*ref*/)) {
                 m_json_ast = flag;
             } else if (onoff(sw, "-lint-only", flag /*ref*/)) {
                 m_lintOnly = flag;
@@ -1133,13 +1133,13 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
                 m_xInitialEdge = flag;
             } else if (onoff(sw, "-xml-only", flag /*ref*/)) {
                 m_xmlOnly = flag;
-            } else if ( onoff (sw, "-json-ast", flag/*ref*/)) {
+            } else if (onoff(sw, "-json-ast", flag /*ref*/)) {
                 m_json_ast = flag;
-            } else if ( onoff (sw, "-uhdm-ast", flag/*ref*/)) {
+            } else if (onoff(sw, "-uhdm-ast", flag /*ref*/)) {
                 m_uhdm_ast = flag;
-            } else if ( onoff (sw, "-uhdm-ast-sv", flag/*ref*/)) {
+            } else if (onoff(sw, "-uhdm-ast-sv", flag /*ref*/)) {
                 m_uhdm_ast_sv = flag;
-            } else if ( onoff (sw, "-dump-uhdm", flag/*ref*/)) {
+            } else if (onoff(sw, "-dump-uhdm", flag /*ref*/)) {
                 m_dump_uhdm = flag;
             } else {
                 hadSwitchPart1 = false;
@@ -1500,8 +1500,9 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc, char
                 VTimescale::parseSlashed(fl, argv[i], unit /*ref*/, prec /*ref*/);
                 if (!unit.isNone() && timeOverrideUnit().isNone()) m_timeDefaultUnit = unit;
                 if (!prec.isNone() && timeOverridePrec().isNone()) m_timeDefaultPrec = prec;
-            } else if (!strcmp(sw, "-uhdm-cov") && (i+1)<argc) {
-                shift; m_uhdmCovFile = argv[i];
+            } else if (!strcmp(sw, "-uhdm-cov") && (i + 1) < argc) {
+                shift;
+                m_uhdmCovFile = argv[i];
             } else if (!strcmp(sw, "-timescale-override") && (i + 1) < argc) {
                 shift;
                 VTimescale unit;

--- a/src/uhdm_dump.cpp
+++ b/src/uhdm_dump.cpp
@@ -44,10225 +44,9584 @@
 namespace UHDM {
 
 static std::string visit_value(s_vpi_value* value) {
-  if (value == nullptr)
+    if (value == nullptr) return "";
+    switch (value->format) {
+    case vpiIntVal: {
+        return std::string(std::string("|INT:") + std::to_string(value->value.integer) + "\n");
+        break;
+    }
+    case vpiStringVal: {
+        const char* s = (const char*)value->value.str;
+        return std::string(std::string("|STRING:") + std::string(s) + "\n");
+        break;
+    }
+    case vpiBinStrVal: {
+        const char* s = (const char*)value->value.str;
+        return std::string(std::string("|BIN:") + std::string(s) + "\n");
+        break;
+    }
+    case vpiHexStrVal: {
+        const char* s = (const char*)value->value.str;
+        return std::string(std::string("|HEX:") + std::string(s) + "\n");
+        break;
+    }
+    case vpiOctStrVal: {
+        const char* s = (const char*)value->value.str;
+        return std::string(std::string("|OCT:") + std::string(s) + "\n");
+        break;
+    }
+    case vpiRealVal: {
+        return std::string(std::string("|REAL:") + std::to_string(value->value.real) + "\n");
+        break;
+    }
+    case vpiScalarVal: {
+        return std::string(std::string("|SCAL:") + std::to_string(value->value.scalar) + "\n");
+        break;
+    }
+    default: break;
+    }
     return "";
-  switch (value->format) {
-  case vpiIntVal: {
-    return std::string(std::string("|INT:") + std::to_string(value->value.integer) + "\n");
-    break;
-  }
-  case vpiStringVal: {
-    const char* s = (const char*) value->value.str;
-    return std::string(std::string("|STRING:") + std::string(s) + "\n");
-    break;
-  }
-  case vpiBinStrVal: {
-    const char* s = (const char*) value->value.str;
-    return std::string(std::string("|BIN:") + std::string(s) + "\n");
-    break;
-  }
-  case vpiHexStrVal: {
-    const char* s = (const char*) value->value.str;
-    return std::string(std::string("|HEX:") + std::string(s) + "\n");
-    break;
-  }
-  case vpiOctStrVal: {
-    const char* s = (const char*) value->value.str;
-    return std::string(std::string("|OCT:") + std::string(s) + "\n");
-    break;
-  }
-  case vpiRealVal: {
-    return std::string(std::string("|REAL:") + std::to_string(value->value.real) + "\n");
-    break;
-  }
-  case vpiScalarVal: {
-    return std::string(std::string("|SCAL:") + std::to_string(value->value.scalar) + "\n");
-    break;
-  }
-  default:
-    break;
-  }
-  return "";
 }
 
 static std::string visit_delays(s_vpi_delay* delay) {
-  if (delay == nullptr)
+    if (delay == nullptr) return "";
+    switch (delay->time_type) {
+    case vpiScaledRealTime: {
+        return std::string(std::string("|#") + std::to_string(delay->da[0].low) + "\n");
+        break;
+    }
+    default: break;
+    }
     return "";
-  switch (delay->time_type) {
-  case vpiScaledRealTime: {
-    return std::string(std::string("|#") + std::to_string(delay->da[0].low) + "\n");
-    break;
-  }
-  default:
-    break;
-  }
-  return "";
 }
 
-static std::ostream &stream_indent(std::ostream &out, int indent) {
-  return out;
-}
-
-static void visit_object (vpiHandle obj_h, int indent, const char *relation, std::set<const BaseClass*>* visited, std::ostream& out, std::ostream& fout) {
-  static constexpr int kLevelIndent = 2;
-
-  unsigned int subobject_indent = indent + kLevelIndent;
-  const uhdm_handle* const handle = (const uhdm_handle*) obj_h;
-  const BaseClass* const object = (const BaseClass*) handle->object;
-  const unsigned int objectType = vpi_get(vpiType, obj_h);
-  const bool alreadyVisited = visited->find(object) != visited->end();
-  visited->insert(object);
-
-  std::string fileName;
-  unsigned int line;
-  {
-    std::string hspaces;
-    std::string rspaces;
-    if (indent >= kLevelIndent) {
-      for (int i = 0; i < indent -2 ; i++) {
-        hspaces += " ";
-      }
-      rspaces = hspaces + "|";
-      hspaces += "\\_";
-    }
-
-    if (strlen(relation) != 0) {
-      out << rspaces << relation << ":\n";
-    }
-    out << hspaces << UHDM::VpiTypeName(obj_h) << ": ";
-    bool needs_separator = false;
-    if (const char* s = vpi_get_str(vpiDefName, obj_h)) {  // defName
-      out << s;
-      needs_separator = true;
-    }
-    if (const char* s = vpi_get_str(vpiName, obj_h)) {   // objectName
-      if (needs_separator) out << " ";
-      out << "(" << s << ")";  // objectName
-    }
-    out << ", id:" << object->UhdmId();
-    if (const char* s = vpi_get_str(vpiFile, obj_h)) {
-        out << ", file:" << s;  // fileName
-        fileName = s;
-    }
-    if (unsigned int l = vpi_get(vpiLineNo, obj_h)) {
-      out << ", line:" << l;
-      line = l;
-    }
-    if (vpiHandle par = vpi_handle(vpiParent, obj_h)) {
-      if (const char* parentName = vpi_get_str(vpiName, par)) {
-        out << ", parent:" << parentName;
-      }
-      vpi_free_object(par);
-    }
-    out << "\n";
-  }
-
-  if (alreadyVisited) {
-    return;
-  }
-
-  if (fileName != "")
-    fout << fileName << ":"
-         << line << ":"
-         << UHDM::VpiTypeName(obj_h) << std::endl;
-
-  if (strcmp(relation, "vpiParent") == 0) {
-    return;
-  }
-  if (objectType == vpiClassObj) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiSimpleExpr) {
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiAssertion) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const int n = vpi_get(vpiStartLine, obj_h))
-      stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
-    if (const int n = vpi_get(vpiColumn, obj_h))
-      stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
-    if (const int n = vpi_get(vpiEndLine, obj_h))
-      stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
-    if (const int n = vpi_get(vpiEndColumn, obj_h))
-      stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiClockingBlock,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiImmediateAssert) {
-    if (const int n = vpi_get(vpiIsDeferred, obj_h))
-      stream_indent(out, indent) << "|vpiIsDeferred:" << n << "\n";
-    if (const int n = vpi_get(vpiIsFinal, obj_h))
-      stream_indent(out, indent) << "|vpiIsFinal:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const int n = vpi_get(vpiStartLine, obj_h))
-      stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
-    if (const int n = vpi_get(vpiColumn, obj_h))
-      stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
-    if (const int n = vpi_get(vpiEndLine, obj_h))
-      stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
-    if (const int n = vpi_get(vpiEndColumn, obj_h))
-      stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiElseStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiElseStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiClockingBlock,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiInterface) {
-    if (const int n = vpi_get(vpiIndex, obj_h))
-      stream_indent(out, indent) << "|vpiIndex:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDefName, obj_h))
-      stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDefFile, obj_h))
-      stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiLibrary, obj_h))
-      stream_indent(out, indent) << "|vpiLibrary:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiCell, obj_h))
-      stream_indent(out, indent) << "|vpiCell:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiConfig, obj_h))
-      stream_indent(out, indent) << "|vpiConfig:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiCellInstance, obj_h))
-      stream_indent(out, indent) << "|vpiCellInstance:" << n << "\n";
-    if (const int n = vpi_get(vpiDefNetType, obj_h))
-      stream_indent(out, indent) << "|vpiDefNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiDefDelayMode, obj_h))
-      stream_indent(out, indent) << "|vpiDefDelayMode:" << n << "\n";
-    if (const int n = vpi_get(vpiProtected, obj_h))
-      stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
-    if (const int n = vpi_get(vpiTimePrecision, obj_h))
-      stream_indent(out, indent) << "|vpiTimePrecision:" << n << "\n";
-    if (const int n = vpi_get(vpiTimeUnit, obj_h))
-      stream_indent(out, indent) << "|vpiTimeUnit:" << n << "\n";
-    if (const int n = vpi_get(vpiUnconnDrive, obj_h))
-      stream_indent(out, indent) << "|vpiUnconnDrive:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiTop, obj_h))
-      stream_indent(out, indent) << "|vpiTop:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiInstanceArray,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstanceArray", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProcess,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProcess", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInterfaceTfDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInterfaceTfDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiGlobalClocking,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiGlobalClocking", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiDefaultClocking,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDefaultClocking", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModPath,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModPath", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInterface,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInterface", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInterfaceArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInterfaceArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPort,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPort", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiGenScopeArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiGenScopeArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiDefaultDisableIff,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDefaultDisableIff", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTaskFunc,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTaskFunc", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArrayNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAssertion,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiClassDefn,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiClassDefn", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgram,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgramArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSpecParam,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSpecParam", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiParameter) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiConstType, obj_h))
-      stream_indent(out, indent) << "|vpiConstType:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiLocalParam, obj_h))
-      stream_indent(out, indent) << "|vpiLocalParam:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTchkTerm) {
-    if (const int n = vpi_get(vpiEdge, obj_h))
-      stream_indent(out, indent) << "|vpiEdge:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPrimitive) {
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiClockedProp) {
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiClockingEvent,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingEvent", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPropertyExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPropertyExpr", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiEnumConst) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-
-    return;
-  }
-  if (objectType == vpiLogicNet) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiExpanded, obj_h))
-      stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiNetType, obj_h))
-      stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiResolvedNetType, obj_h))
-      stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitScalared, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    if (const int n = vpi_get(vpiChargeStrength, obj_h))
-      stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitVectored, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiSimNet,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPathTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchkTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiAttribute) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDefFile, obj_h))
-      stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
-    if (const int n = vpi_get(vpiDefAttribute, obj_h))
-      stream_indent(out, indent) << "|vpiDefAttribute:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-    if (const int n = vpi_get(vpiDefLineNo, obj_h))
-      stream_indent(out, indent) << "|vpiDefLineNo:" << n << "\n";
-
-
-    return;
-  }
-  if (objectType == vpiPort) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiExplicitName, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitName:" << s << "\n";
-    if (const int n = vpi_get(vpiPortIndex, obj_h))
-      stream_indent(out, indent) << "|vpiPortIndex:" << n << "\n";
-    if (const int n = vpi_get(vpiPortType, obj_h))
-      stream_indent(out, indent) << "|vpiPortType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiConnByName, obj_h))
-      stream_indent(out, indent) << "|vpiConnByName:" << n << "\n";
-    if (const int n = vpi_get(vpiDirection, obj_h))
-      stream_indent(out, indent) << "|vpiDirection:" << n << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypedef,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedef", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiHighConn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiHighConn", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLowConn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLowConn", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTaskCall) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTask,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTask", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArgument,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiProgramArray) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInstance,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModule,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiReg) {
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiIndex,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiChandleVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiReturn) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiSwitchArray) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiDelay,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimitive,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInstance,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModule,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiContAssign) {
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiDelay,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiWhile) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPropertyTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiStructTypespec) {
-    if (const int n = vpi_get(vpiPacked, obj_h))
-      stream_indent(out, indent) << "|vpiPacked:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiTypespecMember,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypespecMember", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiEnumTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiBaseTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiBaseTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiEnumConst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiEnumConst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiFork) {
-    if (const int n = vpi_get(vpiJoinType, obj_h))
-      stream_indent(out, indent) << "|vpiJoinType:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiStmt,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiStmt", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiRepeat) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiAssert) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const int n = vpi_get(vpiStartLine, obj_h))
-      stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
-    if (const int n = vpi_get(vpiColumn, obj_h))
-      stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
-    if (const int n = vpi_get(vpiEndLine, obj_h))
-      stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
-    if (const int n = vpi_get(vpiEndColumn, obj_h))
-      stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiIsClockInferred, obj_h))
-      stream_indent(out, indent) << "|vpiIsClockInferred:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiClockingBlock,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiElseStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiElseStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiClockingEvent,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingEvent", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiProperty,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiProperty", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiDesign) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    if (indent == 0) visited->clear();
-    itr = vpi_iterate(uhdmallPackages,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "uhdmallPackages", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    if (indent == 0) visited->clear();
-    itr = vpi_iterate(uhdmallClasses,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "uhdmallClasses", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    if (indent == 0) visited->clear();
-    itr = vpi_iterate(uhdmallInterfaces,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "uhdmallInterfaces", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    if (indent == 0) visited->clear();
-    itr = vpi_iterate(uhdmallUdps,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "uhdmallUdps", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    if (indent == 0) visited->clear();
-    itr = vpi_iterate(uhdmallPrograms,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "uhdmallPrograms", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    if (indent == 0) visited->clear();
-    itr = vpi_iterate(uhdmallModules,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "uhdmallModules", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    if (indent == 0) visited->clear();
-    itr = vpi_iterate(uhdmtopModules,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "uhdmtopModules", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiLogicTypespec) {
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiIndexTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndexTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiElemTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiElemTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPropertyInst) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const int n = vpi_get(vpiStartLine, obj_h))
-      stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
-    if (const int n = vpi_get(vpiColumn, obj_h))
-      stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
-    if (const int n = vpi_get(vpiEndLine, obj_h))
-      stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
-    if (const int n = vpi_get(vpiEndColumn, obj_h))
-      stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiPropertyDecl,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiDisableCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDisableCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArgument,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiClockingBlock,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiGenVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiGenScopeArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiGenScopeArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiBitTypespec) {
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiIndexTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndexTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiElemTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiElemTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPackedArrayNet) {
-    if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiExpanded, obj_h))
-      stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiNetType, obj_h))
-      stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiResolvedNetType, obj_h))
-      stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitScalared, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    if (const int n = vpi_get(vpiChargeStrength, obj_h))
-      stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitVectored, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiElement,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiElement", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiSimNet,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPathTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchkTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiByteVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiBreak) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiSysFuncCall) {
-    if (const int n = vpi_get(vpiFuncType, obj_h))
-      stream_indent(out, indent) << "|vpiFuncType:" << n << "\n";
-    if (const int n = vpi_get(vpiUserDefn, obj_h))
-      stream_indent(out, indent) << "|vpiUserDefn:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiUserSystf,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiUserSystf", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArgument,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiArrayNet) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiExpanded, obj_h))
-      stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiNetType, obj_h))
-      stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiResolvedNetType, obj_h))
-      stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitScalared, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    if (const int n = vpi_get(vpiChargeStrength, obj_h))
-      stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitVectored, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiSimNet,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPathTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchkTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiModport) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiIODecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIODecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInterface,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInterface", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiEnumVar) {
-    if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiIndex,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiStructVar) {
-    if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiMember,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMember", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiIndex,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiEventTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiNamedEvent) {
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiIntTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiNet) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiExpanded, obj_h))
-      stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiNetType, obj_h))
-      stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiResolvedNetType, obj_h))
-      stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitScalared, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    if (const int n = vpi_get(vpiChargeStrength, obj_h))
-      stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitVectored, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiSimNet,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPathTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchkTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiForever) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiInterfaceTfDecl) {
-    if (const int n = vpi_get(vpiAccessType, obj_h))
-      stream_indent(out, indent) << "|vpiAccessType:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiTask,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTask", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiFunction,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiFunction", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiFinal) {
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiRepeatControl) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPackedArrayTypespec) {
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiIndexTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndexTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiElemTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiElemTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiConstant) {
-    if (const int n = vpi_get(vpiConstType, obj_h))
-      stream_indent(out, indent) << "|vpiConstType:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPortBit) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiExplicitName, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitName:" << s << "\n";
-    if (const int n = vpi_get(vpiPortIndex, obj_h))
-      stream_indent(out, indent) << "|vpiPortIndex:" << n << "\n";
-    if (const int n = vpi_get(vpiPortType, obj_h))
-      stream_indent(out, indent) << "|vpiPortType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiConnByName, obj_h))
-      stream_indent(out, indent) << "|vpiConnByName:" << n << "\n";
-    if (const int n = vpi_get(vpiDirection, obj_h))
-      stream_indent(out, indent) << "|vpiDirection:" << n << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedef,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedef", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiHighConn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiHighConn", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLowConn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLowConn", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiShortRealVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiLetDecl) {
-
-
-    return;
-  }
-  if (objectType == vpiImmediateAssume) {
-    if (const int n = vpi_get(vpiIsDeferred, obj_h))
-      stream_indent(out, indent) << "|vpiIsDeferred:" << n << "\n";
-    if (const int n = vpi_get(vpiIsFinal, obj_h))
-      stream_indent(out, indent) << "|vpiIsFinal:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const int n = vpi_get(vpiStartLine, obj_h))
-      stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
-    if (const int n = vpi_get(vpiColumn, obj_h))
-      stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
-    if (const int n = vpi_get(vpiEndLine, obj_h))
-      stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
-    if (const int n = vpi_get(vpiEndColumn, obj_h))
-      stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiElseStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiElseStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiClockingBlock,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiUnionTypespec) {
-    if (const int n = vpi_get(vpiPacked, obj_h))
-      stream_indent(out, indent) << "|vpiPacked:" << n << "\n";
-    if (const int n = vpi_get(vpiTagged, obj_h))
-      stream_indent(out, indent) << "|vpiTagged:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiTypespecMember,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypespecMember", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiParamAssign) {
-    if (const int n = vpi_get(vpiConnByName, obj_h))
-      stream_indent(out, indent) << "|vpiConnByName:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiIntegerVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiMethodFuncCall) {
-    if (const int n = vpi_get(vpiUserDefn, obj_h))
-      stream_indent(out, indent) << "|vpiUserDefn:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiPrefix,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPrefix", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiWith,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiWith", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArgument,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiUserSystf) {
-
-
-    return;
-  }
-  if (objectType == vpiPrimTerm) {
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiStringVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPropertySpec) {
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiClockingEvent,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingEvent", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiDisableCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDisableCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPropertyExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPropertyExpr", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiDelayControl) {
-    s_vpi_delay delay;
-    vpi_get_delays(obj_h, &delay);
-    if (delay.da != nullptr) {
-      stream_indent(out, indent) << visit_delays(&delay);
-    }
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiDelay,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiExpectStmt) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiElseStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiElseStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiOperation) {
-    if (const int n = vpi_get(vpiOpType, obj_h))
-      stream_indent(out, indent) << "|vpiOpType:" << n << "\n";
-    if (const int n = vpi_get(vpiOpStrong, obj_h))
-      stream_indent(out, indent) << "|vpiOpStrong:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiOperand,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiOperand", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiClassTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiShortIntVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiEventControl) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiCaseItem) {
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiExpr,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiExpr", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiGenScope) {
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiProtected, obj_h))
-      stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiIndex,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArrayNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProcess,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProcess", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimitive,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimitiveArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimitiveArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAssertion,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModule,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModuleArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModuleArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDefParam,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDefParam", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiGenScopeArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiGenScopeArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgram,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgramArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInterface,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInterface", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInterfaceArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInterfaceArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAliasStmt,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAliasStmt", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiClockingBlock,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiClockingBlock", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPathTerm) {
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPropertyDecl) {
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiAssignStmt) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiRhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiSysTfCall) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArgument,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiSequenceTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiNetBit) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiExpanded, obj_h))
-      stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiNetType, obj_h))
-      stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiResolvedNetType, obj_h))
-      stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitScalared, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    if (const int n = vpi_get(vpiChargeStrength, obj_h))
-      stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitVectored, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiSimNet,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPathTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchkTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiUdpDefn) {
-
-
-    return;
-  }
-  if (objectType == vpiShortIntTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiFunction) {
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    if (const int n = vpi_get(vpiFuncType, obj_h))
-      stream_indent(out, indent) << "|vpiFuncType:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDPICIdentifier, obj_h))
-      stream_indent(out, indent) << "|vpiDPICIdentifier:" << s << "\n";
-    if (const int n = vpi_get(vpiMethod, obj_h))
-      stream_indent(out, indent) << "|vpiMethod:" << n << "\n";
-    if (const int n = vpi_get(vpiAccessType, obj_h))
-      stream_indent(out, indent) << "|vpiAccessType:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVirtual, obj_h))
-      stream_indent(out, indent) << "|vpiVirtual:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiDPIContext, obj_h))
-      stream_indent(out, indent) << "|vpiDPIContext:" << n << "\n";
-    if (const int n = vpi_get(vpiDPICStr, obj_h))
-      stream_indent(out, indent) << "|vpiDPICStr:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiReturn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiReturn", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiClassDefn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClassDefn", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIODecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIODecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiSequenceInst) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const int n = vpi_get(vpiStartLine, obj_h))
-      stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
-    if (const int n = vpi_get(vpiColumn, obj_h))
-      stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
-    if (const int n = vpi_get(vpiEndLine, obj_h))
-      stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
-    if (const int n = vpi_get(vpiEndColumn, obj_h))
-      stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiClockingBlock,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiDelayTerm) {
-
-
-    return;
-  }
-  if (objectType == vpiNamedFork) {
-    if (const int n = vpi_get(vpiJoinType, obj_h))
-      stream_indent(out, indent) << "|vpiJoinType:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiStmt,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiStmt", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTimeVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiByteTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPorts) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiExplicitName, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitName:" << s << "\n";
-    if (const int n = vpi_get(vpiPortIndex, obj_h))
-      stream_indent(out, indent) << "|vpiPortIndex:" << n << "\n";
-    if (const int n = vpi_get(vpiPortType, obj_h))
-      stream_indent(out, indent) << "|vpiPortType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiConnByName, obj_h))
-      stream_indent(out, indent) << "|vpiConnByName:" << n << "\n";
-    if (const int n = vpi_get(vpiDirection, obj_h))
-      stream_indent(out, indent) << "|vpiDirection:" << n << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedef,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedef", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiHighConn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiHighConn", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLowConn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLowConn", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiDistribution) {
-
-
-    return;
-  }
-  if (objectType == vpiInitial) {
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiStringTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiIntVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiDoWhile) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiCase) {
-    if (const int n = vpi_get(vpiCaseType, obj_h))
-      stream_indent(out, indent) << "|vpiCaseType:" << n << "\n";
-    if (const int n = vpi_get(vpiQualifier, obj_h))
-      stream_indent(out, indent) << "|vpiQualifier:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiCaseItem,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiCaseItem", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiSysTaskCall) {
-    if (const int n = vpi_get(vpiUserDefn, obj_h))
-      stream_indent(out, indent) << "|vpiUserDefn:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiUserSystf,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiUserSystf", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArgument,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPackage) {
-    if (const int n = vpi_get(vpiUnit, obj_h))
-      stream_indent(out, indent) << "|vpiUnit:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDefName, obj_h))
-      stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDefFile, obj_h))
-      stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiLibrary, obj_h))
-      stream_indent(out, indent) << "|vpiLibrary:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiCell, obj_h))
-      stream_indent(out, indent) << "|vpiCell:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiConfig, obj_h))
-      stream_indent(out, indent) << "|vpiConfig:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiCellInstance, obj_h))
-      stream_indent(out, indent) << "|vpiCellInstance:" << n << "\n";
-    if (const int n = vpi_get(vpiDefNetType, obj_h))
-      stream_indent(out, indent) << "|vpiDefNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiDefDelayMode, obj_h))
-      stream_indent(out, indent) << "|vpiDefDelayMode:" << n << "\n";
-    if (const int n = vpi_get(vpiProtected, obj_h))
-      stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
-    if (const int n = vpi_get(vpiTimePrecision, obj_h))
-      stream_indent(out, indent) << "|vpiTimePrecision:" << n << "\n";
-    if (const int n = vpi_get(vpiTimeUnit, obj_h))
-      stream_indent(out, indent) << "|vpiTimeUnit:" << n << "\n";
-    if (const int n = vpi_get(vpiUnconnDrive, obj_h))
-      stream_indent(out, indent) << "|vpiUnconnDrive:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiTop, obj_h))
-      stream_indent(out, indent) << "|vpiTop:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiTaskFunc,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTaskFunc", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArrayNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAssertion,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiClassDefn,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiClassDefn", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgram,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgramArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSpecParam,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSpecParam", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiModPath) {
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiRealVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiStmt) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiLogicVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiIf) {
-    if (const int n = vpi_get(vpiQualifier, obj_h))
-      stream_indent(out, indent) << "|vpiQualifier:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiRefObj) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDefName, obj_h))
-      stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
-    if (const int n = vpi_get(vpiGeneric, obj_h))
-      stream_indent(out, indent) << "|vpiGeneric:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTaskFunc,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTaskFunc", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiActual,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiActual", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiVirtualInterfaceVar) {
-
-
-    return;
-  }
-  if (objectType == vpiIfElse) {
-    if (const int n = vpi_get(vpiQualifier, obj_h))
-      stream_indent(out, indent) << "|vpiQualifier:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiElseStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiElseStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiForeachStmt) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiVariables,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiVariables", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLoopVars,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLoopVars", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiAliasStmt) {
-
-
-    return;
-  }
-  if (objectType == vpiAssignment) {
-    if (const int n = vpi_get(vpiOpType, obj_h))
-      stream_indent(out, indent) << "|vpiOpType:" << n << "\n";
-    if (const int n = vpi_get(vpiBlocking, obj_h))
-      stream_indent(out, indent) << "|vpiBlocking:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiDelayControl,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDelayControl", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiEventControl,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiEventControl", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRepeatControl,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRepeatControl", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiRelease) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTypeParameter) {
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiLocalParam, obj_h))
-      stream_indent(out, indent) << "|vpiLocalParam:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiClassDefn) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiNullStmt) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTimeTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiEnumNet) {
-    if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiExpanded, obj_h))
-      stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiNetType, obj_h))
-      stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiResolvedNetType, obj_h))
-      stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitScalared, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    if (const int n = vpi_get(vpiChargeStrength, obj_h))
-      stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitVectored, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiSimNet,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPathTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchkTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiStructNet) {
-    if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiExpanded, obj_h))
-      stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiNetType, obj_h))
-      stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiResolvedNetType, obj_h))
-      stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitScalared, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    if (const int n = vpi_get(vpiChargeStrength, obj_h))
-      stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitVectored, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiMember,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMember", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiSimNet,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPathTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchkTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiModuleArray) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInstance,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModule,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiContinue) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiMethodTaskCall) {
-    if (const int n = vpi_get(vpiUserDefn, obj_h))
-      stream_indent(out, indent) << "|vpiUserDefn:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiPrefix,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPrefix", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiWith,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiWith", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArgument,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTaskFunc) {
-    if (const char* s = vpi_get_str(vpiDPICIdentifier, obj_h))
-      stream_indent(out, indent) << "|vpiDPICIdentifier:" << s << "\n";
-    if (const int n = vpi_get(vpiMethod, obj_h))
-      stream_indent(out, indent) << "|vpiMethod:" << n << "\n";
-    if (const int n = vpi_get(vpiAccessType, obj_h))
-      stream_indent(out, indent) << "|vpiAccessType:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVirtual, obj_h))
-      stream_indent(out, indent) << "|vpiVirtual:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiDPIContext, obj_h))
-      stream_indent(out, indent) << "|vpiDPIContext:" << n << "\n";
-    if (const int n = vpi_get(vpiDPICStr, obj_h))
-      stream_indent(out, indent) << "|vpiDPICStr:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiReturn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiReturn", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiClassDefn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClassDefn", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIODecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIODecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPackedArrayVar) {
-    if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiPacked, obj_h))
-      stream_indent(out, indent) << "|vpiPacked:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiIndex,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiElement,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiElement", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPartSelect) {
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiParent,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiParent", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiFor) {
-    if (const int n = vpi_get(vpiLocalVarDecls, obj_h))
-      stream_indent(out, indent) << "|vpiLocalVarDecls:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiCondition,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiForInitStmt,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiForInitStmt", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiForIncStmt,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiForIncStmt", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiForInitStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiForInitStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiForIncStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiForIncStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiFuncCall) {
-    if (const int n = vpi_get(vpiFuncType, obj_h))
-      stream_indent(out, indent) << "|vpiFuncType:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiFunction,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiFunction", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArgument,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiDefParam) {
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiRhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiArrayVar) {
-    if (const int n = vpi_get(vpiArrayType, obj_h))
-      stream_indent(out, indent) << "|vpiArrayType:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVarSelect,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVarSelect", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiForce) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiRhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiSequenceDecl) {
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiVariables) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiNamedBegin) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiStmt,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiStmt", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiScope) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiSpecParam) {
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiInstanceArray) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInstance,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModule,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTypespecMember) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiIntegerNet) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiExpanded, obj_h))
-      stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiNetType, obj_h))
-      stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiResolvedNetType, obj_h))
-      stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitScalared, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    if (const int n = vpi_get(vpiChargeStrength, obj_h))
-      stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitVectored, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiSimNet,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPathTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchkTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiRegArray) {
-    if (const int n = vpi_get(vpiIsMemory, obj_h))
-      stream_indent(out, indent) << "|vpiIsMemory:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemoryWord,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemoryWord", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiConstraint) {
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiInterfaceTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiInstance) {
-    if (const char* s = vpi_get_str(vpiDefName, obj_h))
-      stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDefFile, obj_h))
-      stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiLibrary, obj_h))
-      stream_indent(out, indent) << "|vpiLibrary:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiCell, obj_h))
-      stream_indent(out, indent) << "|vpiCell:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiConfig, obj_h))
-      stream_indent(out, indent) << "|vpiConfig:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiCellInstance, obj_h))
-      stream_indent(out, indent) << "|vpiCellInstance:" << n << "\n";
-    if (const int n = vpi_get(vpiDefNetType, obj_h))
-      stream_indent(out, indent) << "|vpiDefNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiDefDelayMode, obj_h))
-      stream_indent(out, indent) << "|vpiDefDelayMode:" << n << "\n";
-    if (const int n = vpi_get(vpiProtected, obj_h))
-      stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
-    if (const int n = vpi_get(vpiTimePrecision, obj_h))
-      stream_indent(out, indent) << "|vpiTimePrecision:" << n << "\n";
-    if (const int n = vpi_get(vpiTimeUnit, obj_h))
-      stream_indent(out, indent) << "|vpiTimeUnit:" << n << "\n";
-    if (const int n = vpi_get(vpiUnconnDrive, obj_h))
-      stream_indent(out, indent) << "|vpiUnconnDrive:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiTop, obj_h))
-      stream_indent(out, indent) << "|vpiTop:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiTaskFunc,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTaskFunc", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArrayNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAssertion,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiClassDefn,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiClassDefn", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgram,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgramArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSpecParam,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSpecParam", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiBegin) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiStmt,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiStmt", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiVoidTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiContAssignBit) {
-    if (const int n = vpi_get(vpiOffset, obj_h))
-      stream_indent(out, indent) << "|vpiOffset:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiDelay,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiClassVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiIndexedPartSelect) {
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiIndexedPartSelectType, obj_h))
-      stream_indent(out, indent) << "|vpiIndexedPartSelectType:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiBaseExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiBaseExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiWidthExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiWidthExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiDeassign) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLhs,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiUdpArray) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiDelay,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimitive,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInstance,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModule,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiGateArray) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiDelay,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimitive,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInstance,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModule,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiUnsupportedExpr) {
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiExpr) {
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiRealTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiProgram) {
-    if (const int n = vpi_get(vpiIndex, obj_h))
-      stream_indent(out, indent) << "|vpiIndex:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDefName, obj_h))
-      stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDefFile, obj_h))
-      stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiLibrary, obj_h))
-      stream_indent(out, indent) << "|vpiLibrary:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiCell, obj_h))
-      stream_indent(out, indent) << "|vpiCell:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiConfig, obj_h))
-      stream_indent(out, indent) << "|vpiConfig:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiCellInstance, obj_h))
-      stream_indent(out, indent) << "|vpiCellInstance:" << n << "\n";
-    if (const int n = vpi_get(vpiDefNetType, obj_h))
-      stream_indent(out, indent) << "|vpiDefNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiDefDelayMode, obj_h))
-      stream_indent(out, indent) << "|vpiDefDelayMode:" << n << "\n";
-    if (const int n = vpi_get(vpiProtected, obj_h))
-      stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
-    if (const int n = vpi_get(vpiTimePrecision, obj_h))
-      stream_indent(out, indent) << "|vpiTimePrecision:" << n << "\n";
-    if (const int n = vpi_get(vpiTimeUnit, obj_h))
-      stream_indent(out, indent) << "|vpiTimeUnit:" << n << "\n";
-    if (const int n = vpi_get(vpiUnconnDrive, obj_h))
-      stream_indent(out, indent) << "|vpiUnconnDrive:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiTop, obj_h))
-      stream_indent(out, indent) << "|vpiTop:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiInstanceArray,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstanceArray", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProcess,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProcess", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiDefaultClocking,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDefaultClocking", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInterface,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInterface", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInterfaceArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInterfaceArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiClockingBlock,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiClockingBlock", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPort,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPort", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiGenScopeArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiGenScopeArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiDefaultDisableIff,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDefaultDisableIff", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTaskFunc,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTaskFunc", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArrayNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAssertion,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiClassDefn,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiClassDefn", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgram,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgramArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSpecParam,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSpecParam", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiVarSelect) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiIndex,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiUnsupportedStmt) {
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiUnionVar) {
-    if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiMember,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMember", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiIndex,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiAlways) {
-    if (const int n = vpi_get(vpiAlwaysType, obj_h))
-      stream_indent(out, indent) << "|vpiAlwaysType:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiGenScopeArray) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiGenVar,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiGenVar", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiGenScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiGenScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiIntegerTypespec) {
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiNets) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiExpanded, obj_h))
-      stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiNetType, obj_h))
-      stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiResolvedNetType, obj_h))
-      stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitScalared, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    if (const int n = vpi_get(vpiChargeStrength, obj_h))
-      stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitVectored, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiSimNet,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPathTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchkTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTchk) {
-    s_vpi_delay delay;
-    vpi_get_delays(obj_h, &delay);
-    if (delay.da != nullptr) {
-      stream_indent(out, indent) << visit_delays(&delay);
-    }
-    if (const int n = vpi_get(vpiTchkType, obj_h))
-      stream_indent(out, indent) << "|vpiTchkType:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiDelay,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkNotifier,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkNotifier", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkRefTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkRefTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkDataTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkDataTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiExpr,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiExpr", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiLongIntVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiArrayTypespec) {
-    if (const int n = vpi_get(vpiArrayType, obj_h))
-      stream_indent(out, indent) << "|vpiArrayType:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiIndexTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndexTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiElemTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiElemTypespec", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTask) {
-    if (const char* s = vpi_get_str(vpiDPICIdentifier, obj_h))
-      stream_indent(out, indent) << "|vpiDPICIdentifier:" << s << "\n";
-    if (const int n = vpi_get(vpiMethod, obj_h))
-      stream_indent(out, indent) << "|vpiMethod:" << n << "\n";
-    if (const int n = vpi_get(vpiAccessType, obj_h))
-      stream_indent(out, indent) << "|vpiAccessType:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVirtual, obj_h))
-      stream_indent(out, indent) << "|vpiVirtual:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiDPIContext, obj_h))
-      stream_indent(out, indent) << "|vpiDPIContext:" << n << "\n";
-    if (const int n = vpi_get(vpiDPICStr, obj_h))
-      stream_indent(out, indent) << "|vpiDPICStr:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiReturn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiReturn", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiClassDefn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClassDefn", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIODecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIODecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiNamedEventArray) {
-
-
-    return;
-  }
-  if (objectType == vpiClockingBlock) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiTimeNet) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const int n = vpi_get(vpiExpanded, obj_h))
-      stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
-    if (const int n = vpi_get(vpiImplicitDecl, obj_h))
-      stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
-    if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
-      stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
-    if (const int n = vpi_get(vpiNetType, obj_h))
-      stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiResolvedNetType, obj_h))
-      stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitScalared, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength0, obj_h))
-      stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
-    if (const int n = vpi_get(vpiStrength1, obj_h))
-      stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
-    if (const int n = vpi_get(vpiChargeStrength, obj_h))
-      stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const int n = vpi_get(vpiExplicitVectored, obj_h))
-      stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLocalLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiSimNet,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPathTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchkTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiRange) {
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiMulticlockSequenceExpr) {
-
-
-    return;
-  }
-  if (objectType == vpiConcurrentAssertions) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiIsClockInferred, obj_h))
-      stream_indent(out, indent) << "|vpiIsClockInferred:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiClockingEvent,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingEvent", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiProperty,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiProperty", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiImmediateCover) {
-    if (const int n = vpi_get(vpiIsDeferred, obj_h))
-      stream_indent(out, indent) << "|vpiIsDeferred:" << n << "\n";
-    if (const int n = vpi_get(vpiIsFinal, obj_h))
-      stream_indent(out, indent) << "|vpiIsFinal:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const int n = vpi_get(vpiStartLine, obj_h))
-      stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
-    if (const int n = vpi_get(vpiColumn, obj_h))
-      stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
-    if (const int n = vpi_get(vpiEndLine, obj_h))
-      stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
-    if (const int n = vpi_get(vpiEndColumn, obj_h))
-      stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiStmt,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiClockingBlock,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiLongIntTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiModule) {
-    if (const int n = vpi_get(vpiIndex, obj_h))
-      stream_indent(out, indent) << "|vpiIndex:" << n << "\n";
-    if (const int n = vpi_get(vpiTopModule, obj_h))
-      stream_indent(out, indent) << "|vpiTopModule:" << n << "\n";
-    if (const int n = vpi_get(vpiDefDecayTime, obj_h))
-      stream_indent(out, indent) << "|vpiDefDecayTime:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDefName, obj_h))
-      stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiDefFile, obj_h))
-      stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiLibrary, obj_h))
-      stream_indent(out, indent) << "|vpiLibrary:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiCell, obj_h))
-      stream_indent(out, indent) << "|vpiCell:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiConfig, obj_h))
-      stream_indent(out, indent) << "|vpiConfig:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiCellInstance, obj_h))
-      stream_indent(out, indent) << "|vpiCellInstance:" << n << "\n";
-    if (const int n = vpi_get(vpiDefNetType, obj_h))
-      stream_indent(out, indent) << "|vpiDefNetType:" << n << "\n";
-    if (const int n = vpi_get(vpiDefDelayMode, obj_h))
-      stream_indent(out, indent) << "|vpiDefDelayMode:" << n << "\n";
-    if (const int n = vpi_get(vpiProtected, obj_h))
-      stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
-    if (const int n = vpi_get(vpiTimePrecision, obj_h))
-      stream_indent(out, indent) << "|vpiTimePrecision:" << n << "\n";
-    if (const int n = vpi_get(vpiTimeUnit, obj_h))
-      stream_indent(out, indent) << "|vpiTimeUnit:" << n << "\n";
-    if (const int n = vpi_get(vpiUnconnDrive, obj_h))
-      stream_indent(out, indent) << "|vpiUnconnDrive:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiTop, obj_h))
-      stream_indent(out, indent) << "|vpiTop:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiInstanceArray,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstanceArray", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProcess,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProcess", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimitive,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimitiveArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimitiveArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiGlobalClocking,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiGlobalClocking", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiDefaultClocking,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDefaultClocking", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModuleArray,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModuleArray", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPort,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPort", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInterface,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInterface", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInterfaceArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInterfaceArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModule,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModuleArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModuleArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModPath,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModPath", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTchk,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTchk", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDefParam,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDefParam", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIODecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIODecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAliasStmt,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAliasStmt", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiClockingBlock,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiClockingBlock", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiGenScopeArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiGenScopeArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiDefaultDisableIff,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDefaultDisableIff", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTaskFunc,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTaskFunc", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiArrayNet,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAssertion,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiClassDefn,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiClassDefn", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgram,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiProgramArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSpecParam,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSpecParam", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiConcurrentAssertions,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVariables,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInternalScope,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiTypedef,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPropertyDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiSequenceDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEvent,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiNamedEventArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiVirtualInterfaceVar,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiReg,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRegArray,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiMemory,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLetDecl,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiParameter,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiImport,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiBitSelect) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiIndex,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiShortRealTypespec) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiTypedefAlias,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiPrimitiveArray) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiDelay,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimitive,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInstance,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModule,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiInterfaceArray) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_iterate(vpiParamAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiInstance,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiModule,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiIODecl) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const int n = vpi_get(vpiDirection, obj_h))
-      stream_indent(out, indent) << "|vpiDirection:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypedef,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypedef", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTaskFunc,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTaskFunc", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiUdpDefn,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiUdpDefn", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiVarBit) {
-    if (const int n = vpi_get(vpiConstantSelect, obj_h))
-      stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiIndex,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-  if (objectType == vpiBitVar) {
-    if (const char* s = vpi_get_str(vpiName, obj_h))
-      stream_indent(out, indent) << "|vpiName:" << s << "\n";
-    if (const char* s = vpi_get_str(vpiFullName, obj_h))
-      stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
-    if (const int n = vpi_get(vpiArrayMember, obj_h))
-      stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
-    if (const int n = vpi_get(vpiSigned, obj_h))
-      stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
-    if (const int n = vpi_get(vpiAutomatic, obj_h))
-      stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
-    if (const int n = vpi_get(vpiAllocScheme, obj_h))
-      stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
-    if (const int n = vpi_get(vpiConstantVariable, obj_h))
-      stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
-    if (const int n = vpi_get(vpiIsRandomized, obj_h))
-      stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
-    if (const int n = vpi_get(vpiRandType, obj_h))
-      stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
-    if (const int n = vpi_get(vpiStructUnionMember, obj_h))
-      stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
-    if (const int n = vpi_get(vpiScalar, obj_h))
-      stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
-    if (const int n = vpi_get(vpiVisibility, obj_h))
-      stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
-    if (const int n = vpi_get(vpiVector, obj_h))
-      stream_indent(out, indent) << "|vpiVector:" << n << "\n";
-    if (const char* s = vpi_get_str(vpiDecompile, obj_h))
-      stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
-    if (const int n = vpi_get(vpiSize, obj_h))
-      stream_indent(out, indent) << "|vpiSize:" << n << "\n";
-    s_vpi_value value;
-    vpi_get_value(obj_h, &value);
-    if (value.format) {
-      stream_indent(out, indent) << visit_value(&value);
-    }
-
-    vpiHandle itr;
-    itr = vpi_handle(vpiLeftRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiRightRange,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiRange,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiBit,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPortInst,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiInstance,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiScope,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiExpr,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiIndex,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiPrimTerm,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiContAssign,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiPathTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTchkTerm,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiModule,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiAttribute,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiDriver,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiLoad,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_iterate(vpiUse,obj_h);
-    while (vpiHandle obj = vpi_scan(itr) ) {
-      visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
-      vpi_free_object(obj);
-    }
-    vpi_free_object(itr);
-    itr = vpi_handle(vpiTypespec,obj_h);
-    if (itr)
-      visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
-    vpi_free_object(itr);
-
-    return;
-  }
-
+static std::ostream& stream_indent(std::ostream& out, int indent) { return out; }
+
+static void visit_object(vpiHandle obj_h, int indent, const char* relation,
+                         std::set<const BaseClass*>* visited, std::ostream& out,
+                         std::ostream& fout) {
+    static constexpr int kLevelIndent = 2;
+
+    unsigned int subobject_indent = indent + kLevelIndent;
+    const uhdm_handle* const handle = (const uhdm_handle*)obj_h;
+    const BaseClass* const object = (const BaseClass*)handle->object;
+    const unsigned int objectType = vpi_get(vpiType, obj_h);
+    const bool alreadyVisited = visited->find(object) != visited->end();
+    visited->insert(object);
+
+    std::string fileName;
+    unsigned int line;
+    {
+        std::string hspaces;
+        std::string rspaces;
+        if (indent >= kLevelIndent) {
+            for (int i = 0; i < indent - 2; i++) { hspaces += " "; }
+            rspaces = hspaces + "|";
+            hspaces += "\\_";
+        }
+
+        if (strlen(relation) != 0) { out << rspaces << relation << ":\n"; }
+        out << hspaces << UHDM::VpiTypeName(obj_h) << ": ";
+        bool needs_separator = false;
+        if (const char* s = vpi_get_str(vpiDefName, obj_h)) {  // defName
+            out << s;
+            needs_separator = true;
+        }
+        if (const char* s = vpi_get_str(vpiName, obj_h)) {  // objectName
+            if (needs_separator) out << " ";
+            out << "(" << s << ")";  // objectName
+        }
+        out << ", id:" << object->UhdmId();
+        if (const char* s = vpi_get_str(vpiFile, obj_h)) {
+            out << ", file:" << s;  // fileName
+            fileName = s;
+        }
+        if (unsigned int l = vpi_get(vpiLineNo, obj_h)) {
+            out << ", line:" << l;
+            line = l;
+        }
+        if (vpiHandle par = vpi_handle(vpiParent, obj_h)) {
+            if (const char* parentName = vpi_get_str(vpiName, par)) {
+                out << ", parent:" << parentName;
+            }
+            vpi_free_object(par);
+        }
+        out << "\n";
+    }
+
+    if (alreadyVisited) { return; }
+
+    if (fileName != "")
+        fout << fileName << ":" << line << ":" << UHDM::VpiTypeName(obj_h) << std::endl;
+
+    if (strcmp(relation, "vpiParent") == 0) { return; }
+    if (objectType == vpiClassObj) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiSimpleExpr) {
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiAssertion) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const int n = vpi_get(vpiStartLine, obj_h))
+            stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
+        if (const int n = vpi_get(vpiColumn, obj_h))
+            stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
+        if (const int n = vpi_get(vpiEndLine, obj_h))
+            stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
+        if (const int n = vpi_get(vpiEndColumn, obj_h))
+            stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiClockingBlock, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiImmediateAssert) {
+        if (const int n = vpi_get(vpiIsDeferred, obj_h))
+            stream_indent(out, indent) << "|vpiIsDeferred:" << n << "\n";
+        if (const int n = vpi_get(vpiIsFinal, obj_h))
+            stream_indent(out, indent) << "|vpiIsFinal:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const int n = vpi_get(vpiStartLine, obj_h))
+            stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
+        if (const int n = vpi_get(vpiColumn, obj_h))
+            stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
+        if (const int n = vpi_get(vpiEndLine, obj_h))
+            stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
+        if (const int n = vpi_get(vpiEndColumn, obj_h))
+            stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiElseStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiElseStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiClockingBlock, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiInterface) {
+        if (const int n = vpi_get(vpiIndex, obj_h))
+            stream_indent(out, indent) << "|vpiIndex:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDefName, obj_h))
+            stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDefFile, obj_h))
+            stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiLibrary, obj_h))
+            stream_indent(out, indent) << "|vpiLibrary:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiCell, obj_h))
+            stream_indent(out, indent) << "|vpiCell:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiConfig, obj_h))
+            stream_indent(out, indent) << "|vpiConfig:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiCellInstance, obj_h))
+            stream_indent(out, indent) << "|vpiCellInstance:" << n << "\n";
+        if (const int n = vpi_get(vpiDefNetType, obj_h))
+            stream_indent(out, indent) << "|vpiDefNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiDefDelayMode, obj_h))
+            stream_indent(out, indent) << "|vpiDefDelayMode:" << n << "\n";
+        if (const int n = vpi_get(vpiProtected, obj_h))
+            stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
+        if (const int n = vpi_get(vpiTimePrecision, obj_h))
+            stream_indent(out, indent) << "|vpiTimePrecision:" << n << "\n";
+        if (const int n = vpi_get(vpiTimeUnit, obj_h))
+            stream_indent(out, indent) << "|vpiTimeUnit:" << n << "\n";
+        if (const int n = vpi_get(vpiUnconnDrive, obj_h))
+            stream_indent(out, indent) << "|vpiUnconnDrive:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiTop, obj_h))
+            stream_indent(out, indent) << "|vpiTop:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiInstanceArray, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstanceArray", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProcess, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProcess", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInterfaceTfDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInterfaceTfDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiGlobalClocking, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiGlobalClocking", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiDefaultClocking, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDefaultClocking", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModPath, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModPath", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInterface, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInterface", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInterfaceArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInterfaceArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPort, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPort", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiGenScopeArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiGenScopeArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiDefaultDisableIff, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDefaultDisableIff", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTaskFunc, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTaskFunc", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArrayNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAssertion, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiClassDefn, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiClassDefn", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgram, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgramArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSpecParam, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSpecParam", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiParameter) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiConstType, obj_h))
+            stream_indent(out, indent) << "|vpiConstType:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiLocalParam, obj_h))
+            stream_indent(out, indent) << "|vpiLocalParam:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTchkTerm) {
+        if (const int n = vpi_get(vpiEdge, obj_h))
+            stream_indent(out, indent) << "|vpiEdge:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPrimitive) {
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiClockedProp) {
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiClockingEvent, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingEvent", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPropertyExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPropertyExpr", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiEnumConst) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        return;
+    }
+    if (objectType == vpiLogicNet) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiExpanded, obj_h))
+            stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiNetType, obj_h))
+            stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiResolvedNetType, obj_h))
+            stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitScalared, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        if (const int n = vpi_get(vpiChargeStrength, obj_h))
+            stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitVectored, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiSimNet, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPathTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchkTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiAttribute) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDefFile, obj_h))
+            stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
+        if (const int n = vpi_get(vpiDefAttribute, obj_h))
+            stream_indent(out, indent) << "|vpiDefAttribute:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+        if (const int n = vpi_get(vpiDefLineNo, obj_h))
+            stream_indent(out, indent) << "|vpiDefLineNo:" << n << "\n";
+
+        return;
+    }
+    if (objectType == vpiPort) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiExplicitName, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitName:" << s << "\n";
+        if (const int n = vpi_get(vpiPortIndex, obj_h))
+            stream_indent(out, indent) << "|vpiPortIndex:" << n << "\n";
+        if (const int n = vpi_get(vpiPortType, obj_h))
+            stream_indent(out, indent) << "|vpiPortType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiConnByName, obj_h))
+            stream_indent(out, indent) << "|vpiConnByName:" << n << "\n";
+        if (const int n = vpi_get(vpiDirection, obj_h))
+            stream_indent(out, indent) << "|vpiDirection:" << n << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypedef, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedef", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiHighConn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiHighConn", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLowConn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLowConn", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTaskCall) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTask, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTask", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArgument, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiProgramArray) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInstance, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModule, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiReg) {
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiIndex, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiChandleVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiReturn) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiSwitchArray) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiDelay, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimitive, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInstance, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModule, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiContAssign) {
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiDelay, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiWhile) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPropertyTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiStructTypespec) {
+        if (const int n = vpi_get(vpiPacked, obj_h))
+            stream_indent(out, indent) << "|vpiPacked:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiTypespecMember, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypespecMember", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiEnumTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiBaseTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiBaseTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiEnumConst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiEnumConst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiFork) {
+        if (const int n = vpi_get(vpiJoinType, obj_h))
+            stream_indent(out, indent) << "|vpiJoinType:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiStmt, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiStmt", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiRepeat) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiAssert) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const int n = vpi_get(vpiStartLine, obj_h))
+            stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
+        if (const int n = vpi_get(vpiColumn, obj_h))
+            stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
+        if (const int n = vpi_get(vpiEndLine, obj_h))
+            stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
+        if (const int n = vpi_get(vpiEndColumn, obj_h))
+            stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiIsClockInferred, obj_h))
+            stream_indent(out, indent) << "|vpiIsClockInferred:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiClockingBlock, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiElseStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiElseStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiClockingEvent, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingEvent", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiProperty, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiProperty", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiDesign) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        if (indent == 0) visited->clear();
+        itr = vpi_iterate(uhdmallPackages, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "uhdmallPackages", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        if (indent == 0) visited->clear();
+        itr = vpi_iterate(uhdmallClasses, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "uhdmallClasses", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        if (indent == 0) visited->clear();
+        itr = vpi_iterate(uhdmallInterfaces, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "uhdmallInterfaces", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        if (indent == 0) visited->clear();
+        itr = vpi_iterate(uhdmallUdps, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "uhdmallUdps", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        if (indent == 0) visited->clear();
+        itr = vpi_iterate(uhdmallPrograms, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "uhdmallPrograms", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        if (indent == 0) visited->clear();
+        itr = vpi_iterate(uhdmallModules, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "uhdmallModules", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        if (indent == 0) visited->clear();
+        itr = vpi_iterate(uhdmtopModules, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "uhdmtopModules", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiLogicTypespec) {
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiIndexTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndexTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiElemTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiElemTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPropertyInst) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const int n = vpi_get(vpiStartLine, obj_h))
+            stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
+        if (const int n = vpi_get(vpiColumn, obj_h))
+            stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
+        if (const int n = vpi_get(vpiEndLine, obj_h))
+            stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
+        if (const int n = vpi_get(vpiEndColumn, obj_h))
+            stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiPropertyDecl, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiDisableCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDisableCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArgument, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiClockingBlock, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiGenVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiGenScopeArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiGenScopeArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiBitTypespec) {
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiIndexTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndexTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiElemTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiElemTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPackedArrayNet) {
+        if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiExpanded, obj_h))
+            stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiNetType, obj_h))
+            stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiResolvedNetType, obj_h))
+            stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitScalared, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        if (const int n = vpi_get(vpiChargeStrength, obj_h))
+            stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitVectored, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiElement, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiElement", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiSimNet, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPathTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchkTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiByteVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiBreak) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiSysFuncCall) {
+        if (const int n = vpi_get(vpiFuncType, obj_h))
+            stream_indent(out, indent) << "|vpiFuncType:" << n << "\n";
+        if (const int n = vpi_get(vpiUserDefn, obj_h))
+            stream_indent(out, indent) << "|vpiUserDefn:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiUserSystf, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiUserSystf", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArgument, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiArrayNet) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiExpanded, obj_h))
+            stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiNetType, obj_h))
+            stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiResolvedNetType, obj_h))
+            stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitScalared, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        if (const int n = vpi_get(vpiChargeStrength, obj_h))
+            stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitVectored, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiSimNet, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPathTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchkTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiModport) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiIODecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIODecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInterface, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInterface", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiEnumVar) {
+        if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiIndex, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiStructVar) {
+        if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiMember, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMember", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiIndex, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiEventTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiNamedEvent) {
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiIntTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiNet) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiExpanded, obj_h))
+            stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiNetType, obj_h))
+            stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiResolvedNetType, obj_h))
+            stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitScalared, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        if (const int n = vpi_get(vpiChargeStrength, obj_h))
+            stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitVectored, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiSimNet, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPathTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchkTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiForever) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiInterfaceTfDecl) {
+        if (const int n = vpi_get(vpiAccessType, obj_h))
+            stream_indent(out, indent) << "|vpiAccessType:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiTask, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTask", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiFunction, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiFunction", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiFinal) {
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiRepeatControl) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPackedArrayTypespec) {
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiIndexTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndexTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiElemTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiElemTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiConstant) {
+        if (const int n = vpi_get(vpiConstType, obj_h))
+            stream_indent(out, indent) << "|vpiConstType:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPortBit) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiExplicitName, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitName:" << s << "\n";
+        if (const int n = vpi_get(vpiPortIndex, obj_h))
+            stream_indent(out, indent) << "|vpiPortIndex:" << n << "\n";
+        if (const int n = vpi_get(vpiPortType, obj_h))
+            stream_indent(out, indent) << "|vpiPortType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiConnByName, obj_h))
+            stream_indent(out, indent) << "|vpiConnByName:" << n << "\n";
+        if (const int n = vpi_get(vpiDirection, obj_h))
+            stream_indent(out, indent) << "|vpiDirection:" << n << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedef, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedef", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiHighConn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiHighConn", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLowConn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLowConn", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiShortRealVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiLetDecl) { return; }
+    if (objectType == vpiImmediateAssume) {
+        if (const int n = vpi_get(vpiIsDeferred, obj_h))
+            stream_indent(out, indent) << "|vpiIsDeferred:" << n << "\n";
+        if (const int n = vpi_get(vpiIsFinal, obj_h))
+            stream_indent(out, indent) << "|vpiIsFinal:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const int n = vpi_get(vpiStartLine, obj_h))
+            stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
+        if (const int n = vpi_get(vpiColumn, obj_h))
+            stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
+        if (const int n = vpi_get(vpiEndLine, obj_h))
+            stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
+        if (const int n = vpi_get(vpiEndColumn, obj_h))
+            stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiElseStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiElseStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiClockingBlock, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiUnionTypespec) {
+        if (const int n = vpi_get(vpiPacked, obj_h))
+            stream_indent(out, indent) << "|vpiPacked:" << n << "\n";
+        if (const int n = vpi_get(vpiTagged, obj_h))
+            stream_indent(out, indent) << "|vpiTagged:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiTypespecMember, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypespecMember", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiParamAssign) {
+        if (const int n = vpi_get(vpiConnByName, obj_h))
+            stream_indent(out, indent) << "|vpiConnByName:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiIntegerVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiMethodFuncCall) {
+        if (const int n = vpi_get(vpiUserDefn, obj_h))
+            stream_indent(out, indent) << "|vpiUserDefn:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiPrefix, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPrefix", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiWith, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiWith", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArgument, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiUserSystf) { return; }
+    if (objectType == vpiPrimTerm) {
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiStringVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPropertySpec) {
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiClockingEvent, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingEvent", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiDisableCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDisableCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPropertyExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPropertyExpr", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiDelayControl) {
+        s_vpi_delay delay;
+        vpi_get_delays(obj_h, &delay);
+        if (delay.da != nullptr) { stream_indent(out, indent) << visit_delays(&delay); }
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiDelay, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiExpectStmt) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiElseStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiElseStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiOperation) {
+        if (const int n = vpi_get(vpiOpType, obj_h))
+            stream_indent(out, indent) << "|vpiOpType:" << n << "\n";
+        if (const int n = vpi_get(vpiOpStrong, obj_h))
+            stream_indent(out, indent) << "|vpiOpStrong:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiOperand, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiOperand", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiClassTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiShortIntVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiEventControl) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiCaseItem) {
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiExpr, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiExpr", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiGenScope) {
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiProtected, obj_h))
+            stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiIndex, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArrayNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProcess, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProcess", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimitive, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimitiveArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimitiveArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAssertion, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModule, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModuleArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModuleArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDefParam, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDefParam", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiGenScopeArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiGenScopeArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgram, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgramArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInterface, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInterface", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInterfaceArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInterfaceArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAliasStmt, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAliasStmt", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiClockingBlock, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiClockingBlock", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPathTerm) {
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPropertyDecl) {
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiAssignStmt) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiRhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiSysTfCall) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArgument, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiSequenceTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiNetBit) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiExpanded, obj_h))
+            stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiNetType, obj_h))
+            stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiResolvedNetType, obj_h))
+            stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitScalared, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        if (const int n = vpi_get(vpiChargeStrength, obj_h))
+            stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitVectored, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiSimNet, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPathTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchkTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiUdpDefn) { return; }
+    if (objectType == vpiShortIntTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiFunction) {
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        if (const int n = vpi_get(vpiFuncType, obj_h))
+            stream_indent(out, indent) << "|vpiFuncType:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDPICIdentifier, obj_h))
+            stream_indent(out, indent) << "|vpiDPICIdentifier:" << s << "\n";
+        if (const int n = vpi_get(vpiMethod, obj_h))
+            stream_indent(out, indent) << "|vpiMethod:" << n << "\n";
+        if (const int n = vpi_get(vpiAccessType, obj_h))
+            stream_indent(out, indent) << "|vpiAccessType:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVirtual, obj_h))
+            stream_indent(out, indent) << "|vpiVirtual:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiDPIContext, obj_h))
+            stream_indent(out, indent) << "|vpiDPIContext:" << n << "\n";
+        if (const int n = vpi_get(vpiDPICStr, obj_h))
+            stream_indent(out, indent) << "|vpiDPICStr:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiReturn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiReturn", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiClassDefn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClassDefn", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIODecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIODecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiSequenceInst) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const int n = vpi_get(vpiStartLine, obj_h))
+            stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
+        if (const int n = vpi_get(vpiColumn, obj_h))
+            stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
+        if (const int n = vpi_get(vpiEndLine, obj_h))
+            stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
+        if (const int n = vpi_get(vpiEndColumn, obj_h))
+            stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiClockingBlock, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiDelayTerm) { return; }
+    if (objectType == vpiNamedFork) {
+        if (const int n = vpi_get(vpiJoinType, obj_h))
+            stream_indent(out, indent) << "|vpiJoinType:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiStmt, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiStmt", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTimeVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiByteTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPorts) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiExplicitName, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitName:" << s << "\n";
+        if (const int n = vpi_get(vpiPortIndex, obj_h))
+            stream_indent(out, indent) << "|vpiPortIndex:" << n << "\n";
+        if (const int n = vpi_get(vpiPortType, obj_h))
+            stream_indent(out, indent) << "|vpiPortType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiConnByName, obj_h))
+            stream_indent(out, indent) << "|vpiConnByName:" << n << "\n";
+        if (const int n = vpi_get(vpiDirection, obj_h))
+            stream_indent(out, indent) << "|vpiDirection:" << n << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedef, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedef", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiHighConn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiHighConn", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLowConn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLowConn", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiDistribution) { return; }
+    if (objectType == vpiInitial) {
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiStringTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiIntVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiDoWhile) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiCase) {
+        if (const int n = vpi_get(vpiCaseType, obj_h))
+            stream_indent(out, indent) << "|vpiCaseType:" << n << "\n";
+        if (const int n = vpi_get(vpiQualifier, obj_h))
+            stream_indent(out, indent) << "|vpiQualifier:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiCaseItem, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiCaseItem", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiSysTaskCall) {
+        if (const int n = vpi_get(vpiUserDefn, obj_h))
+            stream_indent(out, indent) << "|vpiUserDefn:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiUserSystf, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiUserSystf", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArgument, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPackage) {
+        if (const int n = vpi_get(vpiUnit, obj_h))
+            stream_indent(out, indent) << "|vpiUnit:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDefName, obj_h))
+            stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDefFile, obj_h))
+            stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiLibrary, obj_h))
+            stream_indent(out, indent) << "|vpiLibrary:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiCell, obj_h))
+            stream_indent(out, indent) << "|vpiCell:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiConfig, obj_h))
+            stream_indent(out, indent) << "|vpiConfig:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiCellInstance, obj_h))
+            stream_indent(out, indent) << "|vpiCellInstance:" << n << "\n";
+        if (const int n = vpi_get(vpiDefNetType, obj_h))
+            stream_indent(out, indent) << "|vpiDefNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiDefDelayMode, obj_h))
+            stream_indent(out, indent) << "|vpiDefDelayMode:" << n << "\n";
+        if (const int n = vpi_get(vpiProtected, obj_h))
+            stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
+        if (const int n = vpi_get(vpiTimePrecision, obj_h))
+            stream_indent(out, indent) << "|vpiTimePrecision:" << n << "\n";
+        if (const int n = vpi_get(vpiTimeUnit, obj_h))
+            stream_indent(out, indent) << "|vpiTimeUnit:" << n << "\n";
+        if (const int n = vpi_get(vpiUnconnDrive, obj_h))
+            stream_indent(out, indent) << "|vpiUnconnDrive:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiTop, obj_h))
+            stream_indent(out, indent) << "|vpiTop:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiTaskFunc, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTaskFunc", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArrayNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAssertion, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiClassDefn, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiClassDefn", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgram, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgramArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSpecParam, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSpecParam", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiModPath) {
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiRealVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiStmt) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiLogicVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiIf) {
+        if (const int n = vpi_get(vpiQualifier, obj_h))
+            stream_indent(out, indent) << "|vpiQualifier:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiRefObj) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDefName, obj_h))
+            stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
+        if (const int n = vpi_get(vpiGeneric, obj_h))
+            stream_indent(out, indent) << "|vpiGeneric:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTaskFunc, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTaskFunc", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiActual, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiActual", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiVirtualInterfaceVar) { return; }
+    if (objectType == vpiIfElse) {
+        if (const int n = vpi_get(vpiQualifier, obj_h))
+            stream_indent(out, indent) << "|vpiQualifier:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiElseStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiElseStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiForeachStmt) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiVariables, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiVariables", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLoopVars, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLoopVars", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiAliasStmt) { return; }
+    if (objectType == vpiAssignment) {
+        if (const int n = vpi_get(vpiOpType, obj_h))
+            stream_indent(out, indent) << "|vpiOpType:" << n << "\n";
+        if (const int n = vpi_get(vpiBlocking, obj_h))
+            stream_indent(out, indent) << "|vpiBlocking:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiDelayControl, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDelayControl", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiEventControl, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiEventControl", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRepeatControl, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRepeatControl", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiRelease) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTypeParameter) {
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiLocalParam, obj_h))
+            stream_indent(out, indent) << "|vpiLocalParam:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiClassDefn) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiNullStmt) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTimeTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiEnumNet) {
+        if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiExpanded, obj_h))
+            stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiNetType, obj_h))
+            stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiResolvedNetType, obj_h))
+            stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitScalared, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        if (const int n = vpi_get(vpiChargeStrength, obj_h))
+            stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitVectored, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiSimNet, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPathTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchkTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiStructNet) {
+        if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiExpanded, obj_h))
+            stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiNetType, obj_h))
+            stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiResolvedNetType, obj_h))
+            stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitScalared, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        if (const int n = vpi_get(vpiChargeStrength, obj_h))
+            stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitVectored, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiMember, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMember", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiSimNet, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPathTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchkTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiModuleArray) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInstance, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModule, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiContinue) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiMethodTaskCall) {
+        if (const int n = vpi_get(vpiUserDefn, obj_h))
+            stream_indent(out, indent) << "|vpiUserDefn:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiPrefix, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPrefix", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiWith, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiWith", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArgument, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTaskFunc) {
+        if (const char* s = vpi_get_str(vpiDPICIdentifier, obj_h))
+            stream_indent(out, indent) << "|vpiDPICIdentifier:" << s << "\n";
+        if (const int n = vpi_get(vpiMethod, obj_h))
+            stream_indent(out, indent) << "|vpiMethod:" << n << "\n";
+        if (const int n = vpi_get(vpiAccessType, obj_h))
+            stream_indent(out, indent) << "|vpiAccessType:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVirtual, obj_h))
+            stream_indent(out, indent) << "|vpiVirtual:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiDPIContext, obj_h))
+            stream_indent(out, indent) << "|vpiDPIContext:" << n << "\n";
+        if (const int n = vpi_get(vpiDPICStr, obj_h))
+            stream_indent(out, indent) << "|vpiDPICStr:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiReturn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiReturn", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiClassDefn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClassDefn", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIODecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIODecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPackedArrayVar) {
+        if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiPacked, obj_h))
+            stream_indent(out, indent) << "|vpiPacked:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiIndex, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiElement, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiElement", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPartSelect) {
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiParent, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiParent", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiFor) {
+        if (const int n = vpi_get(vpiLocalVarDecls, obj_h))
+            stream_indent(out, indent) << "|vpiLocalVarDecls:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiCondition, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiCondition", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiForInitStmt, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiForInitStmt", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiForIncStmt, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiForIncStmt", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiForInitStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiForInitStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiForIncStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiForIncStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiFuncCall) {
+        if (const int n = vpi_get(vpiFuncType, obj_h))
+            stream_indent(out, indent) << "|vpiFuncType:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiFunction, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiFunction", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArgument, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArgument", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiDefParam) {
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiRhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiArrayVar) {
+        if (const int n = vpi_get(vpiArrayType, obj_h))
+            stream_indent(out, indent) << "|vpiArrayType:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVarSelect, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVarSelect", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiForce) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiRhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiSequenceDecl) {
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiVariables) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiNamedBegin) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiStmt, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiStmt", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiScope) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiSpecParam) {
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiInstanceArray) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInstance, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModule, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTypespecMember) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiIntegerNet) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiExpanded, obj_h))
+            stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiNetType, obj_h))
+            stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiResolvedNetType, obj_h))
+            stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitScalared, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        if (const int n = vpi_get(vpiChargeStrength, obj_h))
+            stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitVectored, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiSimNet, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPathTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchkTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiRegArray) {
+        if (const int n = vpi_get(vpiIsMemory, obj_h))
+            stream_indent(out, indent) << "|vpiIsMemory:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemoryWord, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemoryWord", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiConstraint) {
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiInterfaceTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiInstance) {
+        if (const char* s = vpi_get_str(vpiDefName, obj_h))
+            stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDefFile, obj_h))
+            stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiLibrary, obj_h))
+            stream_indent(out, indent) << "|vpiLibrary:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiCell, obj_h))
+            stream_indent(out, indent) << "|vpiCell:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiConfig, obj_h))
+            stream_indent(out, indent) << "|vpiConfig:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiCellInstance, obj_h))
+            stream_indent(out, indent) << "|vpiCellInstance:" << n << "\n";
+        if (const int n = vpi_get(vpiDefNetType, obj_h))
+            stream_indent(out, indent) << "|vpiDefNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiDefDelayMode, obj_h))
+            stream_indent(out, indent) << "|vpiDefDelayMode:" << n << "\n";
+        if (const int n = vpi_get(vpiProtected, obj_h))
+            stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
+        if (const int n = vpi_get(vpiTimePrecision, obj_h))
+            stream_indent(out, indent) << "|vpiTimePrecision:" << n << "\n";
+        if (const int n = vpi_get(vpiTimeUnit, obj_h))
+            stream_indent(out, indent) << "|vpiTimeUnit:" << n << "\n";
+        if (const int n = vpi_get(vpiUnconnDrive, obj_h))
+            stream_indent(out, indent) << "|vpiUnconnDrive:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiTop, obj_h))
+            stream_indent(out, indent) << "|vpiTop:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiTaskFunc, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTaskFunc", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArrayNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAssertion, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiClassDefn, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiClassDefn", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgram, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgramArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSpecParam, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSpecParam", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiBegin) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiStmt, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiStmt", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiVoidTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiContAssignBit) {
+        if (const int n = vpi_get(vpiOffset, obj_h))
+            stream_indent(out, indent) << "|vpiOffset:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiDelay, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiClassVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiIndexedPartSelect) {
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiIndexedPartSelectType, obj_h))
+            stream_indent(out, indent) << "|vpiIndexedPartSelectType:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiBaseExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiBaseExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiWidthExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiWidthExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiDeassign) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLhs, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLhs", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiUdpArray) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiDelay, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimitive, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInstance, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModule, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiGateArray) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiDelay, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimitive, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInstance, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModule, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiUnsupportedExpr) {
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiExpr) {
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiRealTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiProgram) {
+        if (const int n = vpi_get(vpiIndex, obj_h))
+            stream_indent(out, indent) << "|vpiIndex:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDefName, obj_h))
+            stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDefFile, obj_h))
+            stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiLibrary, obj_h))
+            stream_indent(out, indent) << "|vpiLibrary:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiCell, obj_h))
+            stream_indent(out, indent) << "|vpiCell:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiConfig, obj_h))
+            stream_indent(out, indent) << "|vpiConfig:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiCellInstance, obj_h))
+            stream_indent(out, indent) << "|vpiCellInstance:" << n << "\n";
+        if (const int n = vpi_get(vpiDefNetType, obj_h))
+            stream_indent(out, indent) << "|vpiDefNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiDefDelayMode, obj_h))
+            stream_indent(out, indent) << "|vpiDefDelayMode:" << n << "\n";
+        if (const int n = vpi_get(vpiProtected, obj_h))
+            stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
+        if (const int n = vpi_get(vpiTimePrecision, obj_h))
+            stream_indent(out, indent) << "|vpiTimePrecision:" << n << "\n";
+        if (const int n = vpi_get(vpiTimeUnit, obj_h))
+            stream_indent(out, indent) << "|vpiTimeUnit:" << n << "\n";
+        if (const int n = vpi_get(vpiUnconnDrive, obj_h))
+            stream_indent(out, indent) << "|vpiUnconnDrive:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiTop, obj_h))
+            stream_indent(out, indent) << "|vpiTop:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiInstanceArray, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstanceArray", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProcess, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProcess", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiDefaultClocking, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDefaultClocking", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInterface, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInterface", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInterfaceArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInterfaceArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiClockingBlock, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiClockingBlock", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPort, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPort", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiGenScopeArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiGenScopeArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiDefaultDisableIff, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDefaultDisableIff", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTaskFunc, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTaskFunc", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArrayNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAssertion, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiClassDefn, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiClassDefn", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgram, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgramArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSpecParam, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSpecParam", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiVarSelect) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiIndex, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiUnsupportedStmt) {
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiUnionVar) {
+        if (const int n = vpi_get(vpiPackedArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiPackedArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiMember, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMember", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiIndex, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiAlways) {
+        if (const int n = vpi_get(vpiAlwaysType, obj_h))
+            stream_indent(out, indent) << "|vpiAlwaysType:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiGenScopeArray) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiGenVar, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiGenVar", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiGenScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiGenScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiIntegerTypespec) {
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiNets) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiExpanded, obj_h))
+            stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiNetType, obj_h))
+            stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiResolvedNetType, obj_h))
+            stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitScalared, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        if (const int n = vpi_get(vpiChargeStrength, obj_h))
+            stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitVectored, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiSimNet, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPathTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchkTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTchk) {
+        s_vpi_delay delay;
+        vpi_get_delays(obj_h, &delay);
+        if (delay.da != nullptr) { stream_indent(out, indent) << visit_delays(&delay); }
+        if (const int n = vpi_get(vpiTchkType, obj_h))
+            stream_indent(out, indent) << "|vpiTchkType:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiDelay, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkNotifier, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkNotifier", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkRefTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkRefTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkDataTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkDataTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiExpr, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiExpr", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiLongIntVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiArrayTypespec) {
+        if (const int n = vpi_get(vpiArrayType, obj_h))
+            stream_indent(out, indent) << "|vpiArrayType:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiIndexTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndexTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiElemTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiElemTypespec", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTask) {
+        if (const char* s = vpi_get_str(vpiDPICIdentifier, obj_h))
+            stream_indent(out, indent) << "|vpiDPICIdentifier:" << s << "\n";
+        if (const int n = vpi_get(vpiMethod, obj_h))
+            stream_indent(out, indent) << "|vpiMethod:" << n << "\n";
+        if (const int n = vpi_get(vpiAccessType, obj_h))
+            stream_indent(out, indent) << "|vpiAccessType:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVirtual, obj_h))
+            stream_indent(out, indent) << "|vpiVirtual:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiDPIContext, obj_h))
+            stream_indent(out, indent) << "|vpiDPIContext:" << n << "\n";
+        if (const int n = vpi_get(vpiDPICStr, obj_h))
+            stream_indent(out, indent) << "|vpiDPICStr:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiReturn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiReturn", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiClassDefn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClassDefn", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIODecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIODecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiNamedEventArray) { return; }
+    if (objectType == vpiClockingBlock) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiTimeNet) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const int n = vpi_get(vpiExpanded, obj_h))
+            stream_indent(out, indent) << "|vpiExpanded:" << n << "\n";
+        if (const int n = vpi_get(vpiImplicitDecl, obj_h))
+            stream_indent(out, indent) << "|vpiImplicitDecl:" << n << "\n";
+        if (const int n = vpi_get(vpiNetDeclAssign, obj_h))
+            stream_indent(out, indent) << "|vpiNetDeclAssign:" << n << "\n";
+        if (const int n = vpi_get(vpiNetType, obj_h))
+            stream_indent(out, indent) << "|vpiNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiResolvedNetType, obj_h))
+            stream_indent(out, indent) << "|vpiResolvedNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitScalared, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitScalared:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength0, obj_h))
+            stream_indent(out, indent) << "|vpiStrength0:" << n << "\n";
+        if (const int n = vpi_get(vpiStrength1, obj_h))
+            stream_indent(out, indent) << "|vpiStrength1:" << n << "\n";
+        if (const int n = vpi_get(vpiChargeStrength, obj_h))
+            stream_indent(out, indent) << "|vpiChargeStrength:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const int n = vpi_get(vpiExplicitVectored, obj_h))
+            stream_indent(out, indent) << "|vpiExplicitVectored:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLocalLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLocalLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiSimNet, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiSimNet", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPathTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPathTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchkTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchkTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiRange) {
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiMulticlockSequenceExpr) { return; }
+    if (objectType == vpiConcurrentAssertions) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiIsClockInferred, obj_h))
+            stream_indent(out, indent) << "|vpiIsClockInferred:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiClockingEvent, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingEvent", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiProperty, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiProperty", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiImmediateCover) {
+        if (const int n = vpi_get(vpiIsDeferred, obj_h))
+            stream_indent(out, indent) << "|vpiIsDeferred:" << n << "\n";
+        if (const int n = vpi_get(vpiIsFinal, obj_h))
+            stream_indent(out, indent) << "|vpiIsFinal:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const int n = vpi_get(vpiStartLine, obj_h))
+            stream_indent(out, indent) << "|vpiStartLine:" << n << "\n";
+        if (const int n = vpi_get(vpiColumn, obj_h))
+            stream_indent(out, indent) << "|vpiColumn:" << n << "\n";
+        if (const int n = vpi_get(vpiEndLine, obj_h))
+            stream_indent(out, indent) << "|vpiEndLine:" << n << "\n";
+        if (const int n = vpi_get(vpiEndColumn, obj_h))
+            stream_indent(out, indent) << "|vpiEndColumn:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiStmt, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiStmt", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiClockingBlock, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiClockingBlock", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiLongIntTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiModule) {
+        if (const int n = vpi_get(vpiIndex, obj_h))
+            stream_indent(out, indent) << "|vpiIndex:" << n << "\n";
+        if (const int n = vpi_get(vpiTopModule, obj_h))
+            stream_indent(out, indent) << "|vpiTopModule:" << n << "\n";
+        if (const int n = vpi_get(vpiDefDecayTime, obj_h))
+            stream_indent(out, indent) << "|vpiDefDecayTime:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDefName, obj_h))
+            stream_indent(out, indent) << "|vpiDefName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiDefFile, obj_h))
+            stream_indent(out, indent) << "|vpiDefFile:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiLibrary, obj_h))
+            stream_indent(out, indent) << "|vpiLibrary:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiCell, obj_h))
+            stream_indent(out, indent) << "|vpiCell:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiConfig, obj_h))
+            stream_indent(out, indent) << "|vpiConfig:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiCellInstance, obj_h))
+            stream_indent(out, indent) << "|vpiCellInstance:" << n << "\n";
+        if (const int n = vpi_get(vpiDefNetType, obj_h))
+            stream_indent(out, indent) << "|vpiDefNetType:" << n << "\n";
+        if (const int n = vpi_get(vpiDefDelayMode, obj_h))
+            stream_indent(out, indent) << "|vpiDefDelayMode:" << n << "\n";
+        if (const int n = vpi_get(vpiProtected, obj_h))
+            stream_indent(out, indent) << "|vpiProtected:" << n << "\n";
+        if (const int n = vpi_get(vpiTimePrecision, obj_h))
+            stream_indent(out, indent) << "|vpiTimePrecision:" << n << "\n";
+        if (const int n = vpi_get(vpiTimeUnit, obj_h))
+            stream_indent(out, indent) << "|vpiTimeUnit:" << n << "\n";
+        if (const int n = vpi_get(vpiUnconnDrive, obj_h))
+            stream_indent(out, indent) << "|vpiUnconnDrive:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiTop, obj_h))
+            stream_indent(out, indent) << "|vpiTop:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiInstanceArray, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstanceArray", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProcess, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProcess", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimitive, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimitiveArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimitiveArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiGlobalClocking, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiGlobalClocking", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiDefaultClocking, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDefaultClocking", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModuleArray, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModuleArray", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPort, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPort", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInterface, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInterface", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInterfaceArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInterfaceArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModule, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModuleArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModuleArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModPath, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModPath", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTchk, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTchk", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDefParam, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDefParam", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIODecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIODecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAliasStmt, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAliasStmt", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiClockingBlock, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiClockingBlock", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiGenScopeArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiGenScopeArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiDefaultDisableIff, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDefaultDisableIff", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTaskFunc, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTaskFunc", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiArrayNet, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiArrayNet", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAssertion, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAssertion", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiClassDefn, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiClassDefn", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgram, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgram", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiProgramArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiProgramArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSpecParam, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSpecParam", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiConcurrentAssertions, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiConcurrentAssertions", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVariables, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVariables", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInternalScope, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInternalScope", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiTypedef, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiTypedef", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPropertyDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPropertyDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiSequenceDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiSequenceDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEvent, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEvent", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiNamedEventArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiNamedEventArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiVirtualInterfaceVar, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiVirtualInterfaceVar", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiReg, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiReg", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRegArray, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRegArray", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiMemory, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiMemory", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLetDecl, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLetDecl", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiParameter, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParameter", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiImport, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiImport", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiBitSelect) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiIndex, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiShortRealTypespec) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiTypedefAlias, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedefAlias", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiPrimitiveArray) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiDelay, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiDelay", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimitive, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimitive", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInstance, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModule, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiInterfaceArray) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_iterate(vpiParamAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiParamAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiInstance, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiInstance", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiModule, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiModule", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiIODecl) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const int n = vpi_get(vpiDirection, obj_h))
+            stream_indent(out, indent) << "|vpiDirection:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypedef, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypedef", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTaskFunc, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTaskFunc", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiUdpDefn, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiUdpDefn", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiVarBit) {
+        if (const int n = vpi_get(vpiConstantSelect, obj_h))
+            stream_indent(out, indent) << "|vpiConstantSelect:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiIndex, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiIndex", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
+    if (objectType == vpiBitVar) {
+        if (const char* s = vpi_get_str(vpiName, obj_h))
+            stream_indent(out, indent) << "|vpiName:" << s << "\n";
+        if (const char* s = vpi_get_str(vpiFullName, obj_h))
+            stream_indent(out, indent) << "|vpiFullName:" << s << "\n";
+        if (const int n = vpi_get(vpiArrayMember, obj_h))
+            stream_indent(out, indent) << "|vpiArrayMember:" << n << "\n";
+        if (const int n = vpi_get(vpiSigned, obj_h))
+            stream_indent(out, indent) << "|vpiSigned:" << n << "\n";
+        if (const int n = vpi_get(vpiAutomatic, obj_h))
+            stream_indent(out, indent) << "|vpiAutomatic:" << n << "\n";
+        if (const int n = vpi_get(vpiAllocScheme, obj_h))
+            stream_indent(out, indent) << "|vpiAllocScheme:" << n << "\n";
+        if (const int n = vpi_get(vpiConstantVariable, obj_h))
+            stream_indent(out, indent) << "|vpiConstantVariable:" << n << "\n";
+        if (const int n = vpi_get(vpiIsRandomized, obj_h))
+            stream_indent(out, indent) << "|vpiIsRandomized:" << n << "\n";
+        if (const int n = vpi_get(vpiRandType, obj_h))
+            stream_indent(out, indent) << "|vpiRandType:" << n << "\n";
+        if (const int n = vpi_get(vpiStructUnionMember, obj_h))
+            stream_indent(out, indent) << "|vpiStructUnionMember:" << n << "\n";
+        if (const int n = vpi_get(vpiScalar, obj_h))
+            stream_indent(out, indent) << "|vpiScalar:" << n << "\n";
+        if (const int n = vpi_get(vpiVisibility, obj_h))
+            stream_indent(out, indent) << "|vpiVisibility:" << n << "\n";
+        if (const int n = vpi_get(vpiVector, obj_h))
+            stream_indent(out, indent) << "|vpiVector:" << n << "\n";
+        if (const char* s = vpi_get_str(vpiDecompile, obj_h))
+            stream_indent(out, indent) << "|vpiDecompile:" << s << "\n";
+        if (const int n = vpi_get(vpiSize, obj_h))
+            stream_indent(out, indent) << "|vpiSize:" << n << "\n";
+        s_vpi_value value;
+        vpi_get_value(obj_h, &value);
+        if (value.format) { stream_indent(out, indent) << visit_value(&value); }
+
+        vpiHandle itr;
+        itr = vpi_handle(vpiLeftRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiLeftRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiRightRange, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiRightRange", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiRange, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiRange", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiBit, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiBit", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPortInst, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPortInst", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiInstance, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiInstance", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiScope, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiScope", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiExpr, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiExpr", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiIndex, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiIndex", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiPrimTerm, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiPrimTerm", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiContAssign, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiContAssign", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiPathTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiPathTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTchkTerm, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTchkTerm", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiModule, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiModule", visited, out, fout);
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiAttribute, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiAttribute", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiDriver, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiDriver", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiLoad, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiLoad", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_iterate(vpiUse, obj_h);
+        while (vpiHandle obj = vpi_scan(itr)) {
+            visit_object(obj, subobject_indent, "vpiUse", visited, out, fout);
+            vpi_free_object(obj);
+        }
+        vpi_free_object(itr);
+        itr = vpi_handle(vpiTypespec, obj_h);
+        if (itr) visit_object(itr, subobject_indent, "vpiTypespec", visited, out, fout);
+        vpi_free_object(itr);
+
+        return;
+    }
 }
 
 // Public interface
-void dump_visited (const std::vector<vpiHandle>& designs, std::ostream &out, std::ostream &fout) {
-  for (auto design : designs) {
-    std::set<const BaseClass*> visited;
-    visit_object(design, 0, "", &visited, out, fout);
-  }
+void dump_visited(const std::vector<vpiHandle>& designs, std::ostream& out, std::ostream& fout) {
+    for (auto design : designs) {
+        std::set<const BaseClass*> visited;
+        visit_object(design, 0, "", &visited, out, fout);
+    }
 }
 
-std::string dump_visited (const std::vector<vpiHandle>& designs) {
-  std::stringstream out;
-  std::stringstream fout;
-  dump_visited(designs, out, fout);
-  return fout.str();
+std::string dump_visited(const std::vector<vpiHandle>& designs) {
+    std::stringstream out;
+    std::stringstream fout;
+    dump_visited(designs, out, fout);
+    return fout.str();
 }
 
-};
-
+};  // namespace UHDM

--- a/src/uhdm_dump.h
+++ b/src/uhdm_dump.h
@@ -27,18 +27,17 @@
 #include <vector>
 #include "sv_vpi_user.h"
 
-
 #ifndef UHDM_DUMP_H
 #define UHDM_DUMP_H
 
 namespace UHDM {
 
 // Visit designs, dump visited lines to given stream.
-void dump_visited (const std::vector<vpiHandle>& designs, std::ostream &out, std::ostream &fout);
+void dump_visited(const std::vector<vpiHandle>& designs, std::ostream& out, std::ostream& fout);
 
 // Visit designs, return string representation.
-std::string dump_visited (const std::vector<vpiHandle>& designs);
+std::string dump_visited(const std::vector<vpiHandle>& designs);
 
-};
+};  // namespace UHDM
 
 #endif


### PR DESCRIPTION
This PR reformats frontend code according to Verilator standard.
Fixes #34.