### PR TITLE
Enable working Ibex modules

### DIFF
--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -13,7 +13,7 @@ OPEN_TITAN_INCLUDE = \
 	-I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_util_memload_0/rtl
 
 # Working set of Ibex Core files
-TO_SURELOG='/ibex_pkg.sv\|prim_generic_clock_gating.sv\|ibex_prefetch_buffer.sv\|ibex_compressed_decoder.sv\|ibex_fetch_fifo.sv\|ibex_id_stage.sv\|ibex_decoder.sv\|ibex_controller.sv\|ibex_ex_block.sv\|ibex_alu.sv\|ibex_multdiv_fast.sv\|ibex_load_store_unit.sv\|ibex_wb_stage.sv\|ibex_csr.sv\|ibex_register_file_ff.sv\|ibex_pmp.sv\|prim_secded_28_22_enc.sv\|prim_secded_72_64_enc.sv\|prim_secded_28_22_dec.sv\|prim_secded_72_64_dec.sv'
+TO_SURELOG='/ibex_pkg.sv\|prim_generic_clock_gating.sv\|ibex_prefetch_buffer.sv\|ibex_branch_predict.sv\|ibex_compressed_decoder.sv\|ibex_fetch_fifo.sv\|ibex_id_stage.sv\|ibex_decoder.sv\|ibex_dummy_instr.sv\|ibex_controller.sv\|ibex_if_stage.sv\|ibex_ex_block.sv\|ibex_alu.sv\|ibex_multdiv_fast.sv\|ibex_multdiv_slow.sv\|ibex_load_store_unit.sv\|ibex_wb_stage.sv\|ibex_csr.sv\|ibex_register_file_ff.sv\|ibex_register_file_fpga.sv\|ibex_register_file_latch.sv\|ibex_pmp.sv\|prim_secded_28_22_enc.sv\|prim_secded_72_64_enc.sv\|prim_secded_28_22_dec.sv\|prim_secded_72_64_dec.sv'
 
 # Need to readd this to .vc file due to double matching 'ibex_pkg.sv'
 READD='../src/lowrisc_ip_rv_core_ibex_pkg_0.1/rtl/rv_core_ibex_pkg.sv'


### PR DESCRIPTION
This PR enables parsing following modules by Surelog in Opentitan target:
* ibex_branch_predict.sv
* ibex_dummy_instr.sv
* ibex_if_stage.sv
* ibex_multdiv_slow.sv
* ibex_register_file_fpga.sv
* ibex_register_file_latch.sv