### PR TITLE
Fix put_c method

### DIFF
--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -2726,10 +2726,11 @@ AstNode* visit_object(vpiHandle obj_h, UhdmShared& shared) {
                                    nullptr, nullptr);
         }
         visit_one_to_many({vpiArgument}, obj_h, shared, [&](AstNode* item) {
+            AstNode* argp = new AstArg(new FileLine("Uhdm"), "", item);
             if (args == nullptr) {
-                args = item;
+                args = argp;
             } else {
-                args->addNextNull(item);
+                args->addNextNull(argp);
             }
         });
         return new AstMethodCall(new FileLine("uhdm"), from, objectName, args);


### PR DESCRIPTION
`put_c`, the same as other method with arguments were not parsed properly, because arguments weren't of `AstArg` type.
I wrapped argument nodes into AstArg nodes. Now they will be parsed in the same way as in `verilog.y`.