### PR TITLE
Add passing prim modules

### DIFF
--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -50,7 +50,27 @@ prim_secded_hamming_39_32_dec.sv \
 prim_secded_hamming_72_64_enc.sv \
 prim_secded_hamming_72_64_dec.sv \
 prim_pkg.sv \
-prim_util_pkg.sv'
+prim_util_pkg.sv \
+prim_gf_mult.sv \
+prim_generic_pad_wrapper.sv \
+prim_generic_buf.sv \
+prim_otp_pkg.sv \
+prim_dom_and_2share.sv \
+prim_xilinx_buf.sv \
+prim_xilinx_clock_buf.sv \
+prim_xilinx_clock_gating.sv \
+prim_xilinx_clock_mux2.sv \
+prim_xilinx_flop.sv \
+prim_xilinx_pad_wrapper.sv \
+prim_pad_wrapper.sv \
+prim_generic_clock_buf.sv \
+prim_clock_buf.sv \
+prim_generic_clock_mux2.sv \
+prim_buf.sv \
+prim_alert_pkg.sv \
+prim_arbiter_fixed.sv \
+prim_esc_pkg.sv \
+prim_diff_decode.sv'
 
 TO_SURELOG = \
 	$(shell \

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -12,7 +12,7 @@ OPEN_TITAN_INCLUDE = \
 	-I$(OPEN_TITAN_BUILD)/src/lowrisc_dv_dv_macros_0 \
 	-I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_util_memload_0/rtl
 
-# Working set of Ibex Core files
+# Working set of Opentitan files
 SURELOG_FILE_LIST='/ibex_pkg.sv \
 prim_generic_clock_gating.sv \
 ibex_prefetch_buffer.sv \

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -48,7 +48,9 @@ prim_secded_hamming_22_16_dec.sv \
 prim_secded_hamming_39_32_enc.sv \
 prim_secded_hamming_39_32_dec.sv \
 prim_secded_hamming_72_64_enc.sv \
-prim_secded_hamming_72_64_dec.sv'
+prim_secded_hamming_72_64_dec.sv \
+prim_pkg.sv \
+prim_util_pkg.sv'
 
 TO_SURELOG = \
 	$(shell \

--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -13,7 +13,46 @@ OPEN_TITAN_INCLUDE = \
 	-I$(OPEN_TITAN_BUILD)/src/lowrisc_prim_util_memload_0/rtl
 
 # Working set of Ibex Core files
-TO_SURELOG='/ibex_pkg.sv\|prim_generic_clock_gating.sv\|ibex_prefetch_buffer.sv\|ibex_branch_predict.sv\|ibex_compressed_decoder.sv\|ibex_fetch_fifo.sv\|ibex_id_stage.sv\|ibex_decoder.sv\|ibex_dummy_instr.sv\|ibex_controller.sv\|ibex_counter.sv\|ibex_cs_registers.sv\|ibex_if_stage.sv\|ibex_ex_block.sv\|ibex_alu.sv\|ibex_multdiv_fast.sv\|ibex_multdiv_slow.sv\|ibex_load_store_unit.sv\|ibex_wb_stage.sv\|ibex_csr.sv\|ibex_register_file_ff.sv\|ibex_register_file_fpga.sv\|ibex_register_file_latch.sv\|ibex_pmp.sv\|prim_secded_28_22_enc.sv\|prim_secded_72_64_enc.sv\|prim_secded_28_22_dec.sv\|prim_secded_72_64_dec.sv\|prim_generic_ram_1p.sv\|prim_ram_1p.sv\|prim_generic_ram_2p.sv\|prim_ram_2p.sv\|prim_generic_rom.sv\|prim_rom.sv'
+SURELOG_FILE_LIST='/ibex_pkg.sv \
+prim_generic_clock_gating.sv \
+ibex_prefetch_buffer.sv \
+ibex_branch_predict.sv \
+ibex_compressed_decoder.sv \
+ibex_fetch_fifo.sv \
+ibex_id_stage.sv \
+ibex_decoder.sv \
+ibex_dummy_instr.sv \
+ibex_controller.sv \
+ibex_if_stage.sv \
+ibex_ex_block.sv \
+ibex_alu.sv \
+ibex_multdiv_fast.sv \
+ibex_multdiv_slow.sv \
+ibex_load_store_unit.sv \
+ibex_wb_stage.sv \
+ibex_csr.sv \
+ibex_register_file_ff.sv \
+ibex_register_file_fpga.sv \
+ibex_register_file_latch.sv \
+ibex_pmp.sv \
+prim_secded_22_16_enc.sv \
+prim_secded_22_16_dec.sv \
+prim_secded_28_22_enc.sv \
+prim_secded_28_22_dec.sv \
+prim_secded_39_32_enc.sv \
+prim_secded_39_32_dec.sv \
+prim_secded_72_64_enc.sv \
+prim_secded_72_64_dec.sv \
+prim_secded_hamming_22_16_enc.sv \
+prim_secded_hamming_22_16_dec.sv \
+prim_secded_hamming_39_32_enc.sv \
+prim_secded_hamming_39_32_dec.sv \
+prim_secded_hamming_72_64_enc.sv \
+prim_secded_hamming_72_64_dec.sv'
+
+TO_SURELOG = \
+	$(shell \
+		echo \'${SURELOG_FILE_LIST}\' | sed 's/\s/\\|/g' )
 
 # Need to readd this to .vc file due to double matching 'ibex_pkg.sv'
 READD='../src/lowrisc_ip_rv_core_ibex_pkg_0.1/rtl/rv_core_ibex_pkg.sv'


### PR DESCRIPTION
Add a subset of prim modules that were tested to work in Opentitan with current UHDM-Verilator.