### PR TITLE
Revert "Disable unary_op tests"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Generate matrix
         id: generate-matrix
         run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern StreamOp opentitan hier_path unary_op_minus unary_op_not_log unary_op_plus RealValue)"
+          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern StreamOp opentitan hier_path RealValue)"
           echo "::set-output name=matrix::$matrix"
           echo "Matrix: $matrix"
 
@@ -331,7 +331,7 @@ jobs:
       - name: Generate matrix (vcddiff)
         id: generate-matrix-vcddiff
         run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern MultiplePrints OneNetInterf OneNetRange StreamOp opentitan hier_path genscope_cells unary_op_minus unary_op_not_log unary_op_plus RealValue)"
+          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern MultiplePrints OneNetInterf OneNetRange StreamOp opentitan hier_path genscope_cells RealValue)"
           echo "::set-output name=matrix::$matrix"
           echo "matrix vcddiff: $matrix"
 

--- a/Changes
+++ b/Changes
@@ -3,6 +3,11 @@ Revision history for Verilator
 The contributors that suggested a given feature are shown in []. Thanks!
 
 
+* Verilator 4.107 devel
+
+****  Fix tracing empty sc module (#2729).
+
+
 * Verilator 4.101 devel
 
 ****  Support const object new() assignments.

--- a/src/V3Trace.cpp
+++ b/src/V3Trace.cpp
@@ -603,7 +603,8 @@ private:
             AstCFunc* topFuncp = nullptr;
             AstCFunc* subFuncp = nullptr;
             int subStmts = 0;
-            const uint32_t maxCodes = (nAllCodes + parallelism - 1) / parallelism;
+            uint32_t maxCodes = (nAllCodes + parallelism - 1) / parallelism;
+            if (maxCodes < 1) maxCodes = 1;
             uint32_t nCodes = 0;
             const ActCodeSet* prevActSet = nullptr;
             AstIf* ifp = nullptr;

--- a/test_regress/t/t_trace_sc_empty.pl
+++ b/test_regress/t/t_trace_sc_empty.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2019 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['-sc', '--trace'],
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_trace_sc_empty.v
+++ b/test_regress/t/t_trace_sc_empty.v
@@ -1,0 +1,14 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2020 by Wilsn Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+module t
+  (
+   output id0
+   );
+
+   assign id0 = 0;
+
+endmodule


### PR DESCRIPTION
This reverts commit 64f56f8b7d5078fee8d9e5411c3d49690cde1211.

Tests can be enabled after solving Yosys optimization issue:
https://github.com/alainmarcel/uhdm-integration/issues/243
