### PR TITLE
Fix implicit sensitivity list

### DIFF
--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -1640,7 +1640,7 @@ AstNode* visit_object(vpiHandle obj_h, UhdmShared& shared) {
         return new AstAlways(new FileLine("uhdm"), alwaysType, senTree, body);
     }
     case vpiEventControl: {
-        AstSenItem* senItemRoot;
+        AstSenItem* senItemRoot = nullptr;
         AstNode* body = nullptr;
         AstSenTree* senTree = nullptr;
         visit_one_to_one({vpiCondition}, obj_h, shared, [&](AstNode* node) {


### PR DESCRIPTION
This PR is for fixing segfaults when using implicit sensitivity list (always @(*)) in non-debug verilator.