### PR TITLE
Add modules properly parsed by uhdm-verilator

### DIFF
--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -14,6 +14,14 @@ OPEN_TITAN_INCLUDE = \
 
 # Working set of Opentitan files
 SURELOG_FILE_LIST='/ibex_pkg.sv \
+top_pkg.sv \
+dv_test_status_pkg.sv \
+entropy_src_pkg.sv \
+jtag_pkg.sv \
+top_earlgrey_pkg.sv \
+sw_test_status_pkg.sv \
+ibex_tracer_pkg.sv \
+prim_cipher_pkg.sv \
 prim_generic_clock_gating.sv \
 ibex_prefetch_buffer.sv \
 ibex_branch_predict.sv \
@@ -75,7 +83,17 @@ prim_esc_pkg.sv \
 prim_diff_decode.sv \
 gpiodpi.sv \
 spidpi.sv \
-uartdpi.sv\
+uartdpi.sv \
+prim_slicer.sv \
+prim_gate_gen.sv \
+prim_pulse_sync.sv \
+prim_filter_ctr.sv \
+prim_subreg_arb.sv \
+prim_subreg_ext.sv \
+prim_intr_hw.sv \
+pins_if.sv \
+dmidpi.sv \
+jtagdpi.sv \
 usbdpi.sv'
 
 TO_SURELOG = \


### PR DESCRIPTION
I add modules that are properly parsed. They are found by script. 
