### PR TITLE
Don't overwrite directions of functions arguments

### DIFF
--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -643,18 +643,7 @@ AstNode* process_function(vpiHandle obj_h, UhdmShared& shared) {
         functionVarsp = dtypep;
     }
 
-    visit_one_to_many({vpiIODecl}, obj_h, shared, [&](AstNode* itemp) {
-        if (itemp) {
-            // Overwrite direction for arguments
-            auto* iop = VN_CAST(itemp, Var);
-            iop->direction(VDirection::INPUT);
-            if (statementsp)
-                statementsp->addNextNull(iop);
-            else
-                statementsp = iop;
-        }
-    });
-    visit_one_to_many({vpiVariables}, obj_h, shared, [&](AstNode* itemp) {
+    visit_one_to_many({vpiIODecl, vpiVariables}, obj_h, shared, [&](AstNode* itemp) {
         if (itemp) {
             if (statementsp)
                 statementsp->addNextNull(itemp);


### PR DESCRIPTION
When the following file was parsed by uhdm-verilator:
```systemverilog
module top;
  logic[255:0] mem;
  parameter int Width = 256; 
  function int simutil_get_mem(output bit [255:0] val);
    val[Width-1:0] = mem;
    return 1;
  endfunction
endmodule
```
`val` was treated as input argument, because `direction` was overwritten. It then resulted in different types, for example: https://github.com/alainmarcel/uhdm-integration/issues/312
That PR fixes it. 
