### PR TITLE
Update Surelog list

### DIFF
--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -106,7 +106,6 @@ prim_esc_pkg.sv \
 prim_diff_decode.sv \
 gpiodpi.sv \
 spidpi.sv \
-uartdpi.sv \
 prim_slicer.sv \
 prim_gate_gen.sv \
 prim_pulse_sync.sv \
@@ -142,6 +141,7 @@ uart_rx.sv \
 uart_tx.sv \
 usbdev_flop_2syncpulse.sv \
 jtag_mux.sv \
+csrng_state_db.sv \
 usbdpi.sv'
 
 TO_SURELOG = \


### PR DESCRIPTION
uartdpi.sv module should be removed from the Surelog list, because it gives "division by zero" error when parsed by Surelog. 
https://github.com/alainmarcel/uhdm-integration/issues/326
csrng_state_db.sv can be included.