### PR TITLE
Fix parameter handling

### DIFF
--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -1072,7 +1072,12 @@ AstVar* process_parameter(vpiHandle obj_h, UhdmShared& shared, bool get_value) {
 
     AstNodeDType* dtypep = nullptr;
     auto typespec_h = vpi_handle(vpiTypespec, obj_h);
-    if (typespec_h) { dtypep = getDType(typespec_h, shared); }
+    if (typespec_h) {
+        dtypep = getDType(typespec_h, shared);
+    }
+    else {
+        UINFO(7, "No typespec found in vpiParameter " << objectName << std::endl);
+    }
 
     // If no typespec provided assume default
     if (dtypep == nullptr) {


### PR DESCRIPTION
I splitted visiting vpiParameter and vpiParamAssign nodes into different cases and extracted it to the functions.
When it is possible, vpiParameter nodes will be accessed by vpiParamAssign nodes and their value will be parsed only when needed.

During verilation of opentitan and some tests there was the following message printed:
`-Info: Encountered unknown value format 0`
That commit fix it. 