### PR TITLE
Avoid masking errors in pipelines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -306,6 +306,7 @@ jobs:
       run: |
         pip install virtualenv
         ./uhdm-integration/.github/ci.sh
+        set -o pipefail
         ./uhdm-integration/build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator --meminit=rom,uhdm-tests/opentitan/boot_rom_sim_verilator.elf --meminit=flash,uhdm-tests/opentitan/hello_world_sim_verilator.elf | tee output_uhdm_vanilla_verilator/vanilla_verilator_simulation.log
         cp uart0.log output_uhdm_vanilla_verilator/vanilla_verilator_uart.log
         cp trace_core_00000000.log output_uhdm_vanilla_verilator/vanilla_verilator_trace.log
@@ -317,6 +318,7 @@ jobs:
       run: |
         pip install virtualenv
         ./uhdm-integration/.github/ci.sh
+        set -o pipefail
         ./uhdm-integration/build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator --meminit=rom,uhdm-tests/opentitan/boot_rom_sim_verilator.elf --meminit=flash,uhdm-tests/opentitan/hello_world_sim_verilator.elf | tee output_uhdm_vanilla_verilator/uhdm_verilator_simulation.log
         cp uart0.log output_uhdm_vanilla_verilator/uhdm_verilator_uart.log
         cp trace_core_00000000.log output_uhdm_vanilla_verilator/uhdm_verilator_trace.log

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
+set -ex
 cd Surelog && make PREFIX=$PWD/../image/ release install -j $(nproc) && cd ..
-autoconf && ./configure --prefix=$PWD/image && make install
+autoconf && ./configure --prefix=$PWD/image && make -j $(nproc) && make install
 make -C vcddiff PREFIX=./image -j $(nproc)
 cp -p vcddiff/vcddiff image/bin/vcddiff


### PR DESCRIPTION
Previously errors in simulation were suppress by pipeline. This PR fixes it. So errors in simulation should be matched in CI.