### PR TITLE
Retrieve constant sizes from UHDM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Generate matrix
         id: generate-matrix
         run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis assignment-pattern opentitan hier_path ConstSizes TypedefAlias ReturnFunctionCall FunctionWithoutReturn)"
+          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis assignment-pattern opentitan hier_path TypedefAlias ReturnFunctionCall FunctionWithoutReturn)"
           echo "::set-output name=matrix::$matrix"
           echo "Matrix: $matrix"
 

--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -330,7 +330,7 @@ AstNode* get_value_as_node(vpiHandle obj_h, bool need_decompile = false) {
                 valueNodep = new AstConst(make_fileline(obj_h), AstConst::RealDouble(), value);
             } else {
                 valStr = s;
-                if (valStr.find('\'') == std::string::npos)
+                if (valStr.find('\'') == std::string::npos) {
                     if (int size = vpi_get(vpiSize, obj_h)) {
                         if (type == vpiBinaryConst) valStr = "'b" + valStr;
                         else if (type == vpiOctConst) valStr = "'o" + valStr;
@@ -338,13 +338,18 @@ AstNode* get_value_as_node(vpiHandle obj_h, bool need_decompile = false) {
                         else valStr = "'d" + valStr;
                         valStr = std::to_string(size) + valStr;
                     }
-                auto* constp = new AstConst(make_fileline(obj_h), AstConst::StringToParse(), valStr.c_str());
-                auto& num = constp->num();
-                if (num.width() > 32 && num.widthMin() <= 32) {
-                    num.width(32, false);
-                    constp->dtypeSetLogicUnsized(32, 0, VSigning::fromBool(num.isSigned()));
+                    auto* constp = new AstConst(make_fileline(obj_h), AstConst::StringToParse(), valStr.c_str());
+                    auto& num = constp->num();
+                    if (num.width() > 32 && num.widthMin() <= 32) {
+                        num.width(32, false);
+                        num.isSigned(true);
+                        constp = new AstConst(make_fileline(obj_h), num);
+                    }
+                    valueNodep = constp;
+                } else {
+                    auto* constp = new AstConst(make_fileline(obj_h), AstConst::StringToParse(), valStr.c_str());
+                    valueNodep = constp;
                 }
-                valueNodep = constp;
             }
             return valueNodep;
         }
@@ -375,8 +380,11 @@ AstNode* get_value_as_node(vpiHandle obj_h, bool need_decompile = false) {
             valStr = std::to_string(size) + "'d" + valStr;
         auto* constp = new AstConst(make_fileline(obj_h), AstConst::StringToParse(), valStr.c_str());
         auto& num = constp->num();
-        num.width(num.width(), false);
-        constp->dtypeSetLogicUnsized(num.width(), 0, VSigning::fromBool(num.isSigned()));
+        if (num.width() > 32 && num.widthMin() <= 32) {
+            num.width(32, false);
+            num.isSigned(true);
+            constp = new AstConst(make_fileline(obj_h), num);
+        }
         valueNodep = constp;
         break;
     }


### PR DESCRIPTION
Sometimes UHDM contains constants of size greater than 32, but the size doesn't appear in `vpiDecompile`. This causes an error, as in that case Verilator assumes 32 bits.

This PR also fixes problems with segfaults whenever a number parse error happens (by creating `AstConst`s instead of `V3Number`s).

Test: https://github.com/alainmarcel/uhdm-integration/blob/master/tests/ConstSizes/dut.v (not complete, not sure when Surelog decides to use which type of constant)