### PR TITLE
Support cells named like their types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Generate matrix
         id: generate-matrix
         run: |
-          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern StreamOp opentitan hier_path CellNamedLikeModule ConstSizes PackageCast TypedefAlias)"
+          matrix="$(cd uhdm-integration && python list.py -d tests -s ibex synthesis OneClass hello-uvm OneThis array-copy assignment-pattern StreamOp opentitan hier_path ConstSizes PackageCast TypedefAlias)"
           echo "::set-output name=matrix::$matrix"
           echo "Matrix: $matrix"
 

--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -1399,11 +1399,17 @@ AstNode* visit_object(vpiHandle obj_h, UhdmShared& shared) {
         if (it != shared.partial_modules.end()) {
             // Was created before, fill missing
             module = reinterpret_cast<AstModule*>(it->second);
-            AstModule* full_module = nullptr;
-            if (objectName != modType) {
+            // If available, check vpiFullName instead of vpiName, as vpiName can equal vpiDefName
+            std::string fullName = name;
+            if (auto* s = vpi_get_str(vpiFullName, obj_h)) {
+                fullName = s;
+                sanitize_str(fullName);
+            }
+            if (fullName != modType) {
                 static int module_counter;
                 // Not a top module, create separate node with proper params
                 module = module->cloneTree(false);
+                module->user4p(nullptr); // Clear SymEnt
                 // Use more specific name
                 name = modType + "_" + objectName + std::to_string(module_counter++);
             }
@@ -1500,7 +1506,13 @@ AstNode* visit_object(vpiHandle obj_h, UhdmShared& shared) {
             shared.top_param_map[module->name()] = param_map;
         }
 
-        if (objectName != modType) {
+        // If available, check vpiFullName instead of vpiName, as vpiName can equal vpiDefName
+        std::string fullName = name;
+        if (auto* s = vpi_get_str(vpiFullName, obj_h)) {
+            fullName = s;
+            sanitize_str(fullName);
+        }
+        if (fullName != modType) {
             // Not a top module, create instance
             AstPin* modPins = nullptr;
             AstPin* modParams = nullptr;


### PR DESCRIPTION
This PR introduces support for cells named the same as their types. This sort of thing actually appears in OpenTitan: https://github.com/lowRISC/opentitan/blob/af488fb720513851f50ce456bd71e1218d432e83/hw/ip/prim/rtl/prim_pulse_sync.sv#L40

Test: https://github.com/alainmarcel/uhdm-integration/blob/master/tests/CellNamedLikeModule/dut.v