### PR TITLE
Move kmac, otbn, prim_flash modules to UHDM

### DIFF
--- a/uhdm-tests/opentitan/Makefile.in
+++ b/uhdm-tests/opentitan/Makefile.in
@@ -27,7 +27,6 @@ VERILATOR_ONLY_SOURCE_FILENAMES=\
 /prim_generic_clock_inv.sv \
 /prim_rom_adv.sv \
 /ibex_core.sv \
-/prim_edn_req.sv \
 /prim_ram_1p_scr.sv \
 /prim_ram_2p_adv.sv \
 /tlul_fifo_async.sv \
@@ -39,8 +38,6 @@ VERILATOR_ONLY_SOURCE_FILENAMES=\
 /aes_cipher_core.sv \
 /aes_sub_bytes.sv \
 /aes_key_expand.sv \
-/otbn_rf_base.sv \
-/otbn_loop_controller.sv \
 /otp_ctrl_ecc_reg.sv \
 /otp_ctrl_part_buf.sv \
 /otp_ctrl_dai.sv \
@@ -49,16 +46,12 @@ VERILATOR_ONLY_SOURCE_FILENAMES=\
 /rv_core_ibex.sv \
 /rv_dm.sv \
 /keccak_2share.sv \
-/sha3pad.sv \
 /spi_device.sv \
 /uart_core.sv \
 /usbdev_iomux.sv \
 /usbdev.sv \
 /clkmgr.sv \
 /xbar_main.sv \
-/kmac_core.sv \
-/kmac_staterd.sv \
-/kmac.sv \
 /sensor_ctrl.sv \
 /rstmgr.sv \
 /top_earlgrey.sv \
@@ -95,6 +88,7 @@ VERILATOR_AND_SURELOG_SOURCE_FILENAMES=\
 /prim_fifo_sync.sv \
 /tlul_fifo_sync.sv \
 /tlul_socket_1n.sv \
+/prim_edn_req.sv \
 
 # Regexes for grep
 VERILATOR_ONLY_REGEX=$(shell echo ${VERILATOR_ONLY_SOURCE_FILENAMES} | sed 's/\s/\\|/g')


### PR DESCRIPTION
Move `kmac`, `otbn`, `prim_flash` modules to UHDM