### PR TITLE
conda-eda: change url from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/lowRISC/opentitan.git
 [submodule "uhdm-tests/opentitan-210214"]
 	path = uhdm-tests/opentitan/opentitan-210214
-	url = git@github.com:lowRISC/opentitan.git
+	url = https://github.com/lowRISC/opentitan.git


### PR DESCRIPTION
Fixes: https://github.com/hdl/conda-eda/issues/141
This fixes fail on downloading submodules in conda-eda:
```
Warning: failed to download source.  If building, will try again after downloading recipe dependencies.
Error was: 
 Command '['/usr/bin/git', 'submodule', 'update', '--init', '--recursive']' returned non-zero exit status 1.
```
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>

