### PR TITLE
CI: use custom-runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,8 @@ on:
 jobs:
 
   build-binaries:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     env:
       CC: gcc-9
       CXX: g++-9
@@ -18,17 +19,14 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq
-        sudo apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+        apt-get update -qq
+        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev python3 git pkg-config libreadline-dev bison libffi-dev wget autoconf
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 1
-
-    - uses: actions/setup-python@v2
-      with:
-         python-version: '3.7'
 
     - name: Build binaries
       run: |
@@ -69,19 +67,22 @@ jobs:
         TARGET: uhdm/verilator/test-cmake
 
   generate-matrix:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt install -y python3
+          update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
       - name: Checkout master
         uses: actions/checkout@v2
         with:
           submodules: recursive
           fetch-depth: 1
-
-      - uses: actions/setup-python@v2
-        with:
-           python-version: '3.7'
 
       - name: Generate matrix
         id: generate-matrix
@@ -91,19 +92,22 @@ jobs:
           echo "Matrix: $matrix"
 
   generate-ibex-modules:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     outputs:
       matrix: ${{ steps.generate-ibex-modules.outputs.matrix }}
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt install -y python3
+          update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
       - name: Checkout master
         uses: actions/checkout@v2
         with:
           submodules: recursive
           fetch-depth: 1
-
-      - uses: actions/setup-python@v2
-        with:
-           python-version: '3.7'
 
       - name: Generate matrix
         id: generate-ibex-modules
@@ -113,7 +117,8 @@ jobs:
           echo "Matrix: $matrix"
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     needs: [build-binaries, generate-matrix]
     strategy:
       matrix:
@@ -131,17 +136,14 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq
-        sudo apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+        apt-get update -qq
+        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev python3
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 1
-
-    - uses: actions/setup-python@v2
-      with:
-         python-version: '3.7'
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -159,7 +161,8 @@ jobs:
 
 
   ibex-module-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     needs: [build-binaries, generate-ibex-modules]
     strategy:
       matrix:
@@ -178,17 +181,15 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq
-        sudo apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+        apt-get update -qq
+        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev python3 python3-pip git
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 1
-
-    - uses: actions/setup-python@v2
-      with:
-         python-version: '3.7'
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -215,19 +216,22 @@ jobs:
         TARGET: ${{ matrix.TARGET }}
 
   generate-opentitan-modules:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     outputs:
       matrix: ${{ steps.generate-opentitan-modules.outputs.matrix }}
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt install -y python3
+          update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
       - name: Checkout master
         uses: actions/checkout@v2
         with:
           submodules: recursive
           fetch-depth: 1
-
-      - uses: actions/setup-python@v2
-        with:
-           python-version: '3.7'
 
       - name: Generate matrix
         id: generate-opentitan-modules
@@ -237,7 +241,8 @@ jobs:
           echo "Matrix: $matrix"
 
   opentitan-module-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     needs: [build-binaries, generate-opentitan-modules]
     strategy:
       matrix:
@@ -256,17 +261,15 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq
-        sudo apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+        apt-get update -qq
+        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev python3 python3-pip git
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 1
-
-    - uses: actions/setup-python@v2
-      with:
-         python-version: '3.7'
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -292,7 +295,8 @@ jobs:
         TARGET: ${{ matrix.TARGET }}
 
   opentitan-earlgrey-current:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     needs: build-binaries
     env:
       CC: gcc-9
@@ -302,17 +306,15 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq
-        sudo apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev libelf-dev ninja-build
+        apt-get update -qq
+        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev libelf-dev ninja-build python3 python3-pip git
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 1
-
-    - uses: actions/setup-python@v2
-      with:
-         python-version: '3.7'
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -360,7 +362,8 @@ jobs:
         path: output_uhdm_vanilla_verilator
 
   opentitan-earlgrey-210214:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     needs: build-binaries
     env:
       CC: gcc-9
@@ -370,17 +373,15 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq
-        sudo apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev libelf-dev ninja-build
+        apt-get update -qq
+        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev libelf-dev ninja-build python3 python3-pip git
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 1
-
-    - uses: actions/setup-python@v2
-      with:
-         python-version: '3.7'
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -436,7 +437,8 @@ jobs:
         path: output_uhdm_vanilla_verilator
 
   simple-system-sim:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     needs: build-binaries
     env:
       CC: gcc-9
@@ -446,17 +448,15 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq
-        sudo apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev libelf-dev
+        apt-get update -qq
+        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev libelf-dev python3 python3-pip git
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 1
-
-    - uses: actions/setup-python@v2
-      with:
-         python-version: '3.7'
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -493,19 +493,22 @@ jobs:
         path: output_uhdm
 
   generate-matrix-vcddiff:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     outputs:
       matrix: ${{ steps.generate-matrix-vcddiff.outputs.matrix }}
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt install -y python3
+          update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
       - name: Checkout master
         uses: actions/checkout@v2
         with:
           submodules: recursive
           fetch-depth: 1
-
-      - uses: actions/setup-python@v2
-        with:
-           python-version: '3.7'
 
       - name: Generate matrix (vcddiff)
         id: generate-matrix-vcddiff
@@ -515,7 +518,8 @@ jobs:
           echo "matrix vcddiff: $matrix"
 
   tests-vcddiff:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:latest
     needs: [build-binaries, generate-matrix-vcddiff]
     strategy:
       matrix:
@@ -531,17 +535,14 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq
-        sudo apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+        apt-get update -qq
+        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev python3 unzip
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 1
-
-    - uses: actions/setup-python@v2
-      with:
-         python-version: '3.7'
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -601,7 +602,7 @@ jobs:
             archive_format: 'zip',
           });
           var fs = require('fs');
-          fs.writeFileSync("${{github.workspace}}/artifact.zip", Buffer.from(download.data));
+          fs.writeFileSync("artifact.zip", Buffer.from(download.data));
       env:
         TEST_CASE: ${{ matrix.TEST_CASE_VCDDIFF }}
         OWNER: antmicro


### PR DESCRIPTION
This PR moves CI to use custom-runners. ``macos`` job is still running in the github actions CI.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>

