### PR TITLE
Avoid duplicating tasks and processes

### DIFF
--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -2157,7 +2157,6 @@ AstNode* visit_object(vpiHandle obj_h, UhdmShared& shared) {
                 {
                     vpiModule,
                     vpiContAssign,
-                    vpiProcess,
                     vpiTaskFunc,
                 },
                 obj_h, shared, [&](AstNode* node) {


### PR DESCRIPTION
Currently, tasks and processes are being duplicated in the frontend. This PR fixes that by only visiting those nodes once.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>
