### PR TITLE
Add vpiParameter handling from vpiPackage

### DIFF
--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -1863,6 +1863,7 @@ AstNode* visit_object(vpiHandle obj_h, UhdmShared& shared) {
         visit_one_to_many(
             {
                 vpiParamAssign,
+                vpiParameter,
                 vpiProgram,
                 vpiProgramArray,
                 vpiTaskFunc,

--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -1695,7 +1695,7 @@ AstNode* process_typedef(vpiHandle obj_h, UhdmShared& shared) {
     return typedefp;
 }
 
-AstNode* handle_parameters(vpiHandle obj_h, UhdmShared& shared) {
+AstNode* get_parameters(vpiHandle obj_h, UhdmShared& shared) {
     AstNode* parametersp = nullptr;
 
     // Due to problems with sizes of constants,
@@ -1904,7 +1904,7 @@ AstNode* visit_object(vpiHandle obj_h, UhdmShared& shared) {
         vpi_release_handle(typedef_itr);
         if (typedefsp != nullptr) packagep->addStmtp(typedefsp);
 
-        AstNode* parametersp = handle_parameters(obj_h, shared);
+        AstNode* parametersp = get_parameters(obj_h, shared);
         if (parametersp != nullptr) packagep->addStmtp(parametersp);
 
         visit_one_to_many(
@@ -3222,7 +3222,7 @@ AstNode* visit_object(vpiHandle obj_h, UhdmShared& shared) {
         }
         vpi_release_handle(typedef_itr);
 
-        AstNode* parametersp = handle_parameters(obj_h, shared);
+        AstNode* parametersp = get_parameters(obj_h, shared);
         if (statementsp == nullptr)
             statementsp = parametersp;
         else


### PR DESCRIPTION
According to UHDM standard, the `vpiPackage` can contain `vpiParameter` nodes, but I don't know any cases in which the `vpiParameter` doesn't have corresponding `vpiParamAssign.` .
This PR also cleans the code by moving typedefs and parameters handling to separate function. 