### PR TITLE
Handle vpiParameter case as reference

### DIFF
--- a/src/UhdmAst.cpp
+++ b/src/UhdmAst.cpp
@@ -1380,19 +1380,6 @@ AstNode* process_parameter(vpiHandle obj_h, UhdmShared& shared, bool get_value) 
     AstNode* parameterValuep = nullptr;
 
     std::string objectName = get_object_name(obj_h);
-
-    if (get_value) {
-        std::string fullName = get_object_name(obj_h, {vpiFullName});
-        size_t colon_pos = fullName.rfind("::");
-        if (colon_pos != std::string::npos) {
-            AstNode* class_pkg_refp
-                = get_class_package_ref_node(make_fileline(obj_h), fullName, shared);
-
-            AstNode* var_refp = new AstParseRef(make_fileline(obj_h), VParseRefExp::en::PX_TEXT,
-                                                objectName, nullptr, nullptr);
-            return AstDot::newIfPkg(make_fileline(obj_h), class_pkg_refp, var_refp);
-        }
-    }
     if (shared.package_prefix.empty() && is_imported(obj_h)) {
         // Skip imported parameters, they will still be visible in their packages
         // Can't skip in package, as then names from nested imports cannot be resolved
@@ -2319,7 +2306,16 @@ AstNode* visit_object(vpiHandle obj_h, UhdmShared& shared) {
         return varp;
     }
     case vpiParameter: {
-        return process_parameter(obj_h, shared, true);
+        // vpiParameter nodes should be used to parameter declarations
+        // However, Surelog sometimes uses this node instead of vpiRefObj
+        // to reference parameters.
+        // Parameter declarations are handled using process_parameter function
+        // called directly from instances nodes,
+        // so if we encounter vpiParameter node here, it should be handled as reference
+
+        // Take vpiFullName if exists to have reference to package
+        objectName = get_object_name(obj_h, {vpiFullName, vpiName});
+        return get_referenceNode(make_fileline(obj_h), objectName, shared);
     }
     case vpiParamAssign: {
         return process_param_assign(obj_h, shared);


### PR DESCRIPTION
It is needed to https://github.com/antmicro/verilator/pull/641.
It also make the parameter handling cleaner, because we don't return reference when handling declarations. 