### PR TITLE
Fix hardcoded path to /bin/bash -> /usr/bin/env bash

### DIFF
--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 export SURELOG_INSTALL_DIR=$PWD/image
 cd Surelog && make PREFIX=$SURELOG_INSTALL_DIR release install -j $(nproc) && cd ..


### PR DESCRIPTION
The path /bin/bash is not guaranteed to exist on a posix system, but /usr/bin/env is.